### PR TITLE
Register callbacks for return annotations

### DIFF
--- a/examples/wrapt_patching.py
+++ b/examples/wrapt_patching.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":
 
     @wrapt.decorator(adapter=change_image_to_layer)
     def image_as_napari_layer(wrapped, instance=None, args=None, kwargs=None):
-        """Return a decorator that converts skimage functions to accept napari layers."""
+        """Return decorator that converts skimage functions to accept napari layers."""
         image_idx = get_parameter_position(wrapped, "image")
         if len(args) >= (image_idx + 1):
             args = list(args)

--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -603,8 +603,9 @@ def magicgui(
         return wrapper
 
     if function is None:
-        return inner_func 
+        return inner_func
     return inner_func(function)
+
 
 # ######### UTILITY FUNCTIONS ######### #
 
@@ -627,16 +628,18 @@ def register_type(
     type_ : type
         The type for which a widget class or return callback will be provided.
     widget_type : Optional[Type[api.WidgetType]], optional
-        A widget class from the current backend that should be used whenever ``type_`` is
-        used as the type annotation for an argument in a decorated function, by default None
+        A widget class from the current backend that should be used whenever ``type_``
+        is used as the type annotation for an argument in a decorated function,
+        by default None
     choices : enum or iterable or callable, optional
-        If provided, a categorical type widget will always be used for arguments of type 
-        ``type_``, and ``choices`` will be used to populate the widget.  By default None.
+        If provided, a categorical type widget will always be used for arguments of type
+        ``type_``, and ``choices`` will be used to populate the widget.
+        By default None.
     return_callback: callable, optional
         If provided, whenever ``type_`` is declared as the return type of a decorated
-        function, ``return_callback(widget, value)`` will be called whenever the decorated
-        function is called... where ``widget`` is the MagicGui instance, and ``value`` is
-        the return value of the decorated function.
+        function, ``return_callback(widget, value)`` will be called whenever the
+        decorated function is called... where ``widget`` is the MagicGui instance, and
+        ``value`` is the return value of the decorated function.
 
     Raises
     ------
@@ -673,7 +676,7 @@ def reset_type(type_):
 
 def _type2choices(type_: type) -> ChoicesType:
     """Check if choices have been registered for ``type_`` and return if so.
-    
+
     Parameters
     ----------
     type_ : type
@@ -697,7 +700,7 @@ def _type2choices(type_: type) -> ChoicesType:
 
 def _type2callback(type_: type) -> List[ReturnCallback]:
     """Check if return callbacks have been registered for ``type_`` and return if so.
-    
+
     Parameters
     ----------
     type_ : type

--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -42,7 +42,6 @@ from typing import (
     Callable,
     DefaultDict,
     Dict,
-    Generic,
     Iterable,
     TypeVar,
     Optional,
@@ -112,7 +111,7 @@ class WidgetDescriptor:
         delattr(type(obj), self.name)
 
 
-class MagicGuiBase(api.WidgetType, Generic[MagicGuiType]):
+class MagicGuiBase(api.WidgetType):
     """Main base class for MagicGui.
 
     In most cases, this class will be subclassed into a useable MagicGui when the

--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -31,19 +31,36 @@ magicgui : callable
     instantiate a GUI widget.
 """
 
+from collections import defaultdict
 import functools
 import inspect
 import os
 import warnings
 from enum import EnumMeta
-from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Type, Union
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    Generic,
+    Iterable,
+    TypeVar,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    List,
+)
 
 from . import _qt as api
 
-
-ChoicesType = Union[EnumMeta, Iterable, Callable[[api.WidgetType, Type], Iterable]]
+MagicGuiType = TypeVar("MagicGuiType")
+ChoicesCallback = Callable[[MagicGuiType, Type], Iterable]
+ChoicesType = Union[EnumMeta, Iterable, ChoicesCallback]
 _TYPE_DEFS: Dict[type, Type[api.WidgetType]] = {}
 _CHOICES: Dict[type, ChoicesType] = {}
+
+
 SKIP_UNRECOGNIZED_TYPES = os.environ.get("MAGICGUI_SKIP_UNRECOGNIZED_TYPES", False)
 
 
@@ -95,7 +112,7 @@ class WidgetDescriptor:
         delattr(type(obj), self.name)
 
 
-class MagicGuiBase(api.WidgetType):
+class MagicGuiBase(api.WidgetType, Generic[MagicGuiType]):
     """Main base class for MagicGui.
 
     In most cases, this class will be subclassed into a useable MagicGui when the
@@ -264,9 +281,9 @@ class MagicGuiBase(api.WidgetType):
         dtype = dtype or options.get("dtype")
 
         if dtype is not None:
-            arg_type = dtype
+            arg_type: Type = dtype
         elif value is not None:
-            arg_type: Type = type(value)
+            arg_type = type(value)
         else:
             arg_type = type(None)
 
@@ -302,12 +319,12 @@ class MagicGuiBase(api.WidgetType):
                 )
                 if SKIP_UNRECOGNIZED_TYPES:
                     warnings.warn(msg + " Skipping.")
-                    return
+                    return None
                 raise TypeError(msg)
 
         # check if there is already am existintg widget by this name...
         try:
-            existing_widget = self.get_widget(name)
+            existing_widget: Optional[api.WidgetType] = self.get_widget(name)
         except AttributeError:
             existing_widget = None
         if existing_widget:
@@ -475,6 +492,11 @@ class MagicGuiBase(api.WidgetType):
         # finally, call the original function, emit the result as a signal, and return.
         value = self.func(**_kwargs)
         self.called.emit(value)
+
+        return_type = self.func.__annotations__.get("return")
+        if return_type:
+            for callback in _type2callback(return_type):
+                callback(self, value)
         return value
 
     def _current_signature(self):
@@ -493,7 +515,7 @@ class MagicGuiBase(api.WidgetType):
 
 
 def magicgui(
-    function: Callable = None,
+    function: Optional[Callable] = None,
     layout: Union[api.Layout, str] = "horizontal",
     call_button: Union[bool, str] = False,
     auto_call: bool = False,
@@ -551,12 +573,12 @@ def magicgui(
 
     _layout = api.Layout[layout] if isinstance(layout, str) else layout
 
-    def inner_func(func: Callable) -> Type:
+    def inner_func(func: Callable) -> Callable:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> Any:
             if hasattr(func, "_widget"):
                 # a widget has been instantiated
-                return func._widget(*args, **kwargs)
+                return getattr(func, "_widget")(*args, **kwargs)
             return func(*args, **kwargs)
 
         class MagicGui(MagicGuiBase):
@@ -573,17 +595,22 @@ def magicgui(
                     ignore=ignore,
                     **param_options,
                 )
-                wrapper.called = self.called
+                setattr(wrapper, "called", self.called)
                 if show:
                     self.show()
 
-        wrapper.Gui = MagicGui
+        setattr(wrapper, "Gui", MagicGui)
         return wrapper
 
-    return inner_func if function is None else inner_func(function)
-
+    if function is None:
+        return inner_func 
+    return inner_func(function)
 
 # ######### UTILITY FUNCTIONS ######### #
+
+
+ReturnCallback = Callable[[MagicGuiBase, Any], None]
+_RETURN_CALLBACKS: DefaultDict[type, List[ReturnCallback]] = defaultdict(list)
 
 
 def register_type(
@@ -591,23 +618,39 @@ def register_type(
     *,
     widget_type: Optional[Type[api.WidgetType]] = None,
     choices: Optional[ChoicesType] = None,
+    return_callback: Optional[ReturnCallback] = None,
 ) -> None:
     """Register a ``widget_type`` to be used for all parameters with type ``type_``.
 
     Parameters
     ----------
     type_ : type
-        [description]
+        The type for which a widget class or return callback will be provided.
     widget_type : Optional[Type[api.WidgetType]], optional
-        [description], by default None
-    choices : Optional[ChoicesType], optional
-        [description], by default None
+        A widget class from the current backend that should be used whenever ``type_`` is
+        used as the type annotation for an argument in a decorated function, by default None
+    choices : enum or iterable or callable, optional
+        If provided, a categorical type widget will always be used for arguments of type 
+        ``type_``, and ``choices`` will be used to populate the widget.  By default None.
+    return_callback: callable, optional
+        If provided, whenever ``type_`` is declared as the return type of a decorated
+        function, ``return_callback(widget, value)`` will be called whenever the decorated
+        function is called... where ``widget`` is the MagicGui instance, and ``value`` is
+        the return value of the decorated function.
 
     Raises
     ------
     ValueError
         If both ``widget_type`` and ``choices`` are None
     """
+    if not (return_callback or choices or widget_type):
+        raise ValueError(
+            "One of `widget_type`, `choices`, or `return_callback` must be provided."
+        )
+
+    if return_callback is not None:
+        _RETURN_CALLBACKS[type_].append(return_callback)
+
     if choices is not None:
         _CHOICES[type_] = choices
         _TYPE_DEFS[type_] = api.get_categorical_widget()
@@ -618,19 +661,29 @@ def register_type(
             )
     elif widget_type is not None:
         _TYPE_DEFS[type_] = widget_type
-    else:
-        raise ValueError("Either `widget_type` or `choices` must be provided.")
+    return None
 
 
 def reset_type(type_):
-    """Clear any previously-registered widget types for ``type_``."""
-    global _TYPE_DEFS
-    global _CHOICES
+    """Clear any previously-registered widget types and callbacks for ``type_``."""
     _TYPE_DEFS.pop(type_, None)
     _CHOICES.pop(type_, None)
+    _RETURN_CALLBACKS.pop(type_, None)
 
 
-def _type2choices(type_: type) -> Optional[ChoicesType]:
+def _type2choices(type_: type) -> ChoicesType:
+    """Check if choices have been registered for ``type_`` and return if so.
+    
+    Parameters
+    ----------
+    type_ : type
+        The type_ to look up.
+
+    Returns
+    -------
+    iterable or callable or None
+        A choices lookup iterable or callable.
+    """
     # look for direct hits
     if type_ in _CHOICES:
         return _CHOICES[type_]
@@ -639,6 +692,30 @@ def _type2choices(type_: type) -> Optional[ChoicesType]:
         # TODO: is it necessary to check for isclass at this point?
         if inspect.isclass(type_) and issubclass(type_, registered_type):
             return _CHOICES[registered_type]
+    return []
+
+
+def _type2callback(type_: type) -> List[ReturnCallback]:
+    """Check if return callbacks have been registered for ``type_`` and return if so.
+    
+    Parameters
+    ----------
+    type_ : type
+        The type_ to look up.
+
+    Returns
+    -------
+    list of callable
+        Where a return callback accepts two arguments (gui, value) and does something.
+    """
+    # look for direct hits
+    if type_ in _RETURN_CALLBACKS:
+        return _RETURN_CALLBACKS[type_]
+    # look for subclasses
+    for registered_type in _RETURN_CALLBACKS:
+        if inspect.isclass(type_) and issubclass(type_, registered_type):
+            return _RETURN_CALLBACKS[registered_type]
+    return []
 
 
 def type2widget(type_: type) -> Type[api.WidgetType]:

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -438,6 +438,38 @@ def test_register_types(qtbot):
     core.reset_type(int)
 
 
+def test_register_return_callback(qtbot):
+    """Test that registering a return callback works."""
+
+    def check_value(gui, value):
+        assert value == 1
+
+    class Base:
+        pass
+
+    class Sub(Base):
+        pass
+
+    register_type(int, return_callback=check_value)
+    register_type(Base, return_callback=check_value)
+
+    @magicgui
+    def func(a=1) -> int:
+        return a
+
+    _ = func.Gui()
+    func()
+    with pytest.raises(AssertionError):
+        func(3)
+
+    @magicgui
+    def func2(a=1) -> Sub:
+        return a
+
+    _ = func2.Gui()
+    func2()
+
+
 def test_parent_changed(qtbot, magic_widget):
     """Test that setting MagicGui parent emits a signal."""
     with qtbot.waitSignal(magic_widget.parentChanged, timeout=1000):


### PR DESCRIPTION
closes #3  by adding a `return_callback` argument to `register_type`.  Multiple return callbacks can be registered for any given type. 

A side observation here:
the most natural way for an image arithmetic function to work would be for the function to return a numpy array, and _napari_ calls `add_image(array)`

```python
def image_arithmetic(layerA: Image, operation: Operation, layerB: Image) -> np.ndarray:
    return operation.value(layerA.data, layerB.data)
```

but that requires napari to register the type `np.ndarray` and assume they should _all_ be **Image** layers... which is a big assumption.  alternatively, we leave it to the user to return a napari layers, they have build it themselves and return an Image type... then it's easy for napari to know what to do... but the function becomes more napari specific though, I suppose, it already was by nature of accepting napari layers.

```python
def image_arithmetic(layerA: Image, operation: Operation, layerB: Image) -> Image:
    return Image(operation.value(layerA.data, layerB.data))
```

another possible solution is to define a new `LayerData` type which would essentially hand the return value to `_add_layer_from_data`.  But that's all a conversation for another day and doesn't really affect this PR.