### PR TITLE
fix call_button press for pyqt5

### DIFF
--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -188,7 +188,8 @@ class MagicGuiBase(api.WidgetType):
             self.call_button = api.ButtonType(
                 call_button if isinstance(call_button, str) else "call"
             )
-            self.call_button.clicked.connect(self.__call__)
+            # using lambda because the clicked signal returns a value
+            self.call_button.clicked.connect(lambda checked: self.__call__())
             self.layout().addWidget(self.call_button)
 
         if auto_call:

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -100,10 +100,20 @@ def test_no_type_provided(qtbot):
     assert isinstance(gui.get_widget("a"), none_widget)
 
 
-def test_call_button(magic_widget):
-    """Test that the call button has been added."""
+def test_call_button(qtbot):
+    """Test that the call button has been added, and pressing it calls the function."""
+
+    @magicgui(call_button="my_button", auto_call=True)
+    def func(a: int, b: int = 3, c=7.1) -> None:
+        assert a == 7
+
+    magic_widget = func.Gui()
+
     assert hasattr(magic_widget, "call_button")
     assert isinstance(magic_widget.call_button, QtW.QPushButton)
+    magic_widget.a = 7
+
+    qtbot.mouseClick(magic_widget.call_button, Qt.LeftButton)
 
 
 def test_auto_call(qtbot, magic_func):


### PR DESCRIPTION
difference in the way signals are emitted in pyqt5 broke the `call_button` feature.  fixed here, with test