### PR TITLE
Add datetime to type2widget function

### DIFF
--- a/magicgui/_qt.py
+++ b/magicgui/_qt.py
@@ -3,6 +3,7 @@
 
 import sys
 from contextlib import contextmanager
+import datetime
 from enum import Enum, EnumMeta
 from typing import Any, Callable, Dict, Iterable, NamedTuple, Optional, Tuple, Type
 
@@ -152,6 +153,7 @@ def type2widget(type_: type) -> Optional[Type[WidgetType]]:
         int: QSpinBox,
         float: QDoubleSpinBox,
         str: QLineEdit,
+        datetime.datetime: QDateTimeEdit,
         type(None): QLineEdit,
     }
     if type_ in simple:

--- a/magicgui/_qt.py
+++ b/magicgui/_qt.py
@@ -203,9 +203,14 @@ def getter_setter_onchange(widget: WidgetType) -> GetSetOnChange:
     elif isinstance(widget, (QAbstractButton, QGroupBox)):
         return GetSetOnChange(widget.isChecked, widget.setChecked, widget.toggled)
     elif isinstance(widget, QDateTimeEdit):
-        return GetSetOnChange(
-            widget.dateTime, widget.setDateTime, widget.dateTimeChanged
-        )
+
+        def getter():
+            try:
+                return widget.dateTime().toPython()
+            except TypeError:
+                return widget.dateTime().toPyDateTime()
+
+        return GetSetOnChange(getter, widget.setDateTime, widget.dateTimeChanged)
     elif isinstance(widget, (QAbstractSpinBox, QAbstractSlider)):
         return GetSetOnChange(widget.value, widget.setValue, widget.valueChanged)
     elif isinstance(widget, QTabWidget):

--- a/magicgui/_tests/test_ qt.py
+++ b/magicgui/_tests/test_ qt.py
@@ -3,6 +3,7 @@
 """Tests for `magicgui._qt` module."""
 
 from enum import Enum
+import datetime
 
 import pytest
 from qtpy import QtCore
@@ -73,6 +74,12 @@ def test_setters(qtbot):
     w = _qt.make_widget(QtW.QDoubleSpinBox, "spinbox", minimum=2, Maximum=10)
     assert w.minimum() == 2
     assert w.maximum() == 10
+
+
+def test_datetimeedit(qtbot):
+    """Test the datetime getter."""
+    getter, setter, onchange = _qt.getter_setter_onchange(QtW.QDateTimeEdit())
+    assert isinstance(getter(), datetime.datetime)
 
 
 def test_set_categorical(qtbot):


### PR DESCRIPTION
magicgui has support for date time choosers (with PyQt QDateTimeEdit), but there is no automatic inference if you pass in a datetime object. Since `datetime` is part of the standard library, I think it would be nice to add this to the `type2widget` function.
