### PR TITLE
support Sequence[Path]

### DIFF
--- a/examples/file_dialog.py
+++ b/examples/file_dialog.py
@@ -1,6 +1,7 @@
 """FileDialog with magicgui."""
 from pathlib import Path
 from magicgui import event_loop, magicgui
+from typing import Sequence
 
 
 # may also add Qt-style filter to filename options:
@@ -12,6 +13,15 @@ def filepicker(filename=Path("~")):
     return filename
 
 
+# Sequence of paths
+@magicgui()
+def filespicker(filenames: Sequence[Path]):
+    """Take a filename and do something with it."""
+    print("The filenames are:", filenames)
+    return filenames
+
+
 with event_loop():
     gui = filepicker.Gui(show=True)
     gui.filename_changed.connect(print)
+    gui2 = filespicker.Gui(show=True)

--- a/magicgui/_qt.py
+++ b/magicgui/_qt.py
@@ -9,7 +9,7 @@ from collections import abc
 from contextlib import contextmanager
 from enum import Enum, EnumMeta
 from pathlib import Path
-from typing import (  # type: ignore
+from typing import (
     Any,
     Callable,
     Dict,
@@ -20,7 +20,6 @@ from typing import (  # type: ignore
     Tuple,
     Type,
     Union,
-    _GenericAlias,
 )
 
 from qtpy.QtCore import Qt, Signal
@@ -152,7 +151,7 @@ class QDataComboBox(QComboBox):
             self.currentDataChanged.emit(data)
 
 
-def type2widget(type_: Union[type, _GenericAlias]) -> Optional[Type[WidgetType]]:
+def type2widget(type_: Union[type]) -> Optional[Type[WidgetType]]:
     """Convert an python type to Qt widget.
 
     Parameters
@@ -165,11 +164,11 @@ def type2widget(type_: Union[type, _GenericAlias]) -> Optional[Type[WidgetType]]
     WidgetType: Type[WidgetType]
         A WidgetType Class that can be used for arg_type ``type_``.
     """
-    if isinstance(type_, _GenericAlias):
-        org = type_.__origin__
-        arg = type_.__args__
-        arg = arg[0] if len(arg) else None
-        if inspect.isclass(org) and issubclass(org, abc.Sequence):
+    #
+    if hasattr(type_, "__origin__") and hasattr(type_, "__args__"):
+        orig = type_.__origin__  # type: ignore
+        arg = type_.__args__[0] if len(type_.__args__) else None  # type: ignore
+        if inspect.isclass(orig) and issubclass(orig, abc.Sequence):
             if inspect.isclass(arg) and issubclass(arg, Path):
                 return MagicFilesDialog
 

--- a/magicgui/_tests/test_ qt.py
+++ b/magicgui/_tests/test_ qt.py
@@ -163,6 +163,8 @@ def test_magicfiledialog_opens_chooser(qtbot, mode):
 def test_magifiledialog_type2widget(containertype, pathtype):
     """Test we get a MagicFileDialog from a various Path types."""
     if containertype is not None:
-        assert _qt.type2widget(containertype[pathtype]) == _qt.MagicFilesDialog
+        Wdg = _qt.type2widget(containertype[pathtype])
+        assert Wdg == _qt.MagicFilesDialog
+        assert Wdg().mode == _qt.FileDialogMode.EXISTING_FILES
     else:
         assert _qt.type2widget(pathtype) == _qt.MagicFileDialog

--- a/magicgui/_tests/test_ qt.py
+++ b/magicgui/_tests/test_ qt.py
@@ -11,6 +11,7 @@ from qtpy import QtCore
 from qtpy import QtWidgets as QtW
 
 from magicgui import _qt, event_loop
+from typing import Sequence, List, Tuple
 
 
 def test_event():
@@ -109,7 +110,7 @@ def test_magicfiledialog(qtbot):
 
     # check default values
     assert filewidget.get_path() == Path(".")
-    assert filewidget.mode == _qt.FileDialogMode.OPTIONAL_FILE
+    assert filewidget.mode == _qt.FileDialogMode.EXISTING_FILE
 
     # set the mode
     filewidget.mode = _qt.FileDialogMode.EXISTING_FILES  # Enum input
@@ -157,7 +158,11 @@ def test_magicfiledialog_opens_chooser(qtbot, mode):
     filewidget._on_choose_clicked()
 
 
+@pytest.mark.parametrize("containertype", [None, Tuple, List, Sequence])
 @pytest.mark.parametrize("pathtype", [PosixPath, WindowsPath, Path])
-def test_linux_mac_magifiledialog(pathtype):
+def test_magifiledialog_type2widget(containertype, pathtype):
     """Test we get a MagicFileDialog from a various Path types."""
-    assert _qt.type2widget(pathtype) == _qt.MagicFileDialog
+    if containertype is not None:
+        assert _qt.type2widget(containertype[pathtype]) == _qt.MagicFilesDialog
+    else:
+        assert _qt.type2widget(pathtype) == _qt.MagicFileDialog


### PR DESCRIPTION
This PR follows up on #23 and adds support for annotating an argument as a `Sequence` (or `List` or `Tuple`) of `Path` (or `WindowsPath` or `PosixPath`), and getting the appropriate widget that allows you to select multiple files.