### PR TITLE
Widget demo example script

### DIFF
--- a/examples/widget_demo.py
+++ b/examples/widget_demo.py
@@ -3,8 +3,10 @@
 from enum import Enum
 from datetime import datetime
 import math
+from pathlib import Path
 
 from magicgui import event_loop, magicgui
+
 
 class Medium(Enum):
     """Enum for various media and their refractive indices."""
@@ -22,7 +24,8 @@ def widget_demo(
     float=3.14159,
     string="Text goes here",
     dropdown=Medium.Glass,
-    datetime=datetime.now()
+    datetime=datetime.now(),
+    filename=Path.home()
 ):
     """Run some computation."""
     print("Running some computation...")

--- a/examples/widget_demo.py
+++ b/examples/widget_demo.py
@@ -1,0 +1,40 @@
+"""Widget demonstration of magicgui."""
+
+from enum import Enum
+from datetime import datetime
+import math
+
+from magicgui import event_loop, magicgui
+
+class Medium(Enum):
+    """Enum for various media and their refractive indices."""
+
+    Glass = 1.520
+    Oil = 1.515
+    Water = 1.333
+    Air = 1.0003
+
+
+@magicgui(call_button="Calculate", result={"disabled": True, "fixedWidth": 100})
+def widget_demo(
+    boolean=True,
+    integer=1,
+    float=3.14159,
+    string="Text goes here",
+    dropdown=Medium.Glass,
+    datetime=datetime.now()
+):
+    """Run some computation."""
+    print("Running some computation...")
+    return "Result!"
+
+
+with event_loop():
+    # the original function still works
+    # we can create a gui
+    gui = widget_demo.Gui(show=True)
+    # we can list for changes to parameters in the gui
+    # ... these also trigger for direct parameter access on the gui object
+    gui.string_changed.connect(print)
+    # we can connect a callback function to the __call__ event on the function
+    gui.called.connect(lambda x: gui.set_widget("result", str(x), position=-1))


### PR DESCRIPTION
I thought it would be good to have an easy to run example script showcasing all the widget types supported by `magicgui`. 

Right now there's nowhere in the docs or examples that explains all the different types of widgets you can have. I personally learnt most of what I know about the [Gooey](https://github.com/chriskiehl/Gooey) from [their widget demo script](https://github.com/chriskiehl/GooeyExamples/blob/master/examples/widget_demo.py), so that's a big motivation to include something similar here.