### PR TITLE
Fix napari_param_sweep.py example by updating QDoubleSlider import

### DIFF
--- a/docs/examples/napari_parameter_sweep.md
+++ b/docs/examples/napari_parameter_sweep.md
@@ -37,7 +37,7 @@ https://github.com/napari/magicgui/blob/master/examples/napari_param_sweep.py).*
 
     ```python hl_lines="20 21 22 23 24 31 33 35"
     from magicgui import magicgui
-    from magicgui._qt import QDoubleSlider
+    from magicgui._qt.widgets import QDoubleSlider
     import napari
     from napari.layers import Image
     import skimage.data

--- a/examples/napari_param_sweep.py
+++ b/examples/napari_param_sweep.py
@@ -9,7 +9,7 @@ import napari
 import skimage.data
 import skimage.filters
 from magicgui import magicgui
-from magicgui._qt import QDoubleSlider
+from magicgui._qt.widgets import QDoubleSlider
 from napari.layers import Image
 
 


### PR DESCRIPTION
Fixes the `napari_param_sweep.py` example by updating the import path to the `QDoubleSlider` class. Now we can run the example again.

This class was moved in a recent refactor (PR https://github.com/napari/magicgui/pull/32), so we just need to update the example to match.
