### PR TITLE
Add flake8-docstrings to dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 bump2version>=0.5.11
 wheel>=0.33.6
 flake8>=3.7.8
+flake8-docstrings>=1.5.0
 pydocstyle>=5.0.2
 black==19.10b0
 twine>=1.14.0


### PR DESCRIPTION
Add flake8-docstrings to dev requirements, so the pre-commit hook also catches docstring issues.

I was briefly confused earlier today when the `qa(lint)` job failed on CI for my pull request, because I had installed the pre-commit hook and `flake8 magicgui` passed on my local machine. Turns out that this wasn't checking any of the docstrings locally, because I did not have `flake8-docstrings` installed into my development environment. This PR adds `flake8-docstrings` to `requirements/dev.txt`.

