### PR TITLE
Add a "display_name" option to modify a widget's label (#45)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,8 +47,8 @@ def my_func(arg=5):
 ### `display_name`
 
 By default, the label which will be displayed next to the widget will have the
-variable's name. If you wish to modify that you may include in the argument's
-options dictionary the `display_name` key with the desired label:
+variable's name. If you wish to modify that, add a `display_name` entry to the argument's
+options dictionary with the desired label:
 
 ```python
 @magicgui(user_address={'display_name': 'Address'})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,14 +44,14 @@ def my_func(arg=5):
     ...
 ```
 
-### `display_name`
+### `label`
 
 By default, the label which will be displayed next to the widget will have the
-variable's name. If you wish to modify that, add a `display_name` entry to the argument's
+variable's name. If you wish to modify that, add a `label` entry to the argument's
 options dictionary with the desired label:
 
 ```python
-@magicgui(user_address={'display_name': 'Address'})
+@magicgui(user_address={'label': 'Address'})
 def get_address(user_address: str):
     ...
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,18 @@ def my_func(arg=5):
     ...
 ```
 
+### `display_name`
+
+By default, the label which will be displayed next to the widget will have the
+variable's name. If you wish to modify that you may include in the argument's
+options dictionary the `display_name` key with the desired label:
+
+```python
+@magicgui(user_address={'display_name': 'Address'})
+def get_address(user_address: str):
+    ...
+```
+
 ## Qt-specific options
 
 If you are using Qt as a backend (currently the only supported backend), you can provide

--- a/examples/file_dialog.py
+++ b/examples/file_dialog.py
@@ -14,8 +14,8 @@ def filepicker(filename=Path("~")):
 
 
 # Sequence of paths
-# We change the label using "display_name" for added clarity
-@magicgui(filenames={"display_name": "Choose multiple files:"})
+# We change the label using "label" for added clarity
+@magicgui(filenames={"label": "Choose multiple files:"})
 def filespicker(filenames: Sequence[Path]):
     """Take a filename and do something with it."""
     print("The filenames are:", filenames)

--- a/examples/file_dialog.py
+++ b/examples/file_dialog.py
@@ -14,7 +14,8 @@ def filepicker(filename=Path("~")):
 
 
 # Sequence of paths
-@magicgui()
+# We change the label using "display_name" for added clarity
+@magicgui(filenames={"display_name": "Choose multiple files:"})
 def filespicker(filenames: Sequence[Path]):
     """Take a filename and do something with it."""
     print("The filenames are:", filenames)

--- a/magicgui/_tests/test_magicgui.py
+++ b/magicgui/_tests/test_magicgui.py
@@ -66,11 +66,10 @@ def test_overriding_widget_type(qtbot):
     assert gui.a == "1"
 
 
-def test_overriding_arg_display_name(qtbot):
-    """Test that a new label is given to a widget based on
-    the 'display_name' key."""
+def test_overriding_arg_label(qtbot):
+    """Test that `label` overrides the default label text."""
 
-    @magicgui(a={"display_name": "b"})
+    @magicgui(a={"label": "b"})
     def func(a: int = 1):
         pass
 

--- a/magicgui/_tests/test_magicgui.py
+++ b/magicgui/_tests/test_magicgui.py
@@ -66,6 +66,18 @@ def test_overriding_widget_type(qtbot):
     assert gui.a == "1"
 
 
+def test_overriding_arg_display_name(qtbot):
+    """Test that a new label is given to a widget based on
+    the 'display_name' key."""
+
+    @magicgui(a={"display_name": "b"})
+    def func(a: int = 1):
+        pass
+
+    gui = func.Gui()
+    assert gui.children()[-1].text() == "b"
+
+
 def test_overriding_arg_type(qtbot):
     """Test overriding the widget type of a parameter."""
     # a will now be a LineEdit instead of a spinbox

--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -359,7 +359,7 @@ class MagicGuiBase(api.WidgetType):
                 delattr(self, name)
 
         # generate the label that will appear next to the widget
-        display_name = _options.get("display_name", name)
+        display_name = str(_options.get("display_name", name))
         _options.pop("display_name", None)
 
         # instantiate a new widget

--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -359,8 +359,8 @@ class MagicGuiBase(api.WidgetType):
                 delattr(self, name)
 
         # generate the label that will appear next to the widget
-        display_name = str(_options.get("display_name", name))
-        _options.pop("display_name", None)
+        display_name = str(_options.get("label", name))
+        _options.pop("label", None)
 
         # instantiate a new widget
         widget = api.make_widget(WidgetType, name=name, parent=self, **_options)

--- a/magicgui/core.py
+++ b/magicgui/core.py
@@ -343,7 +343,7 @@ class MagicGuiBase(api.WidgetType):
                 # TODO: make this behavior configurable
                 # raise TypeError(msg)
 
-        # check if there is already am existintg widget by this name...
+        # check if there is already an existing widget by this name...
         try:
             existing_widget: Optional[api.WidgetType] = self.get_widget(name)
         except AttributeError:
@@ -357,6 +357,10 @@ class MagicGuiBase(api.WidgetType):
             else:
                 position = self.layout().indexOf(existing_widget)
                 delattr(self, name)
+
+        # generate the label that will appear next to the widget
+        display_name = _options.get("display_name", name)
+        _options.pop("display_name", None)
 
         # instantiate a new widget
         widget = api.make_widget(WidgetType, name=name, parent=self, **_options)
@@ -382,7 +386,7 @@ class MagicGuiBase(api.WidgetType):
         if not is_visible:
             widget.hide()
         # add the widget to the layout (appended, or at a specific position)
-        label = name if (self._with_labels and is_visible) else ""
+        label = display_name if (self._with_labels and is_visible) else ""
 
         if position is not None:
             if not isinstance(position, int):


### PR DESCRIPTION
Addresses #45.

This PR adds the option to modify a widget's label by including a `display_name` key in that argument's specific dictionary.

It also adds a paragraph in the docs, does a small change to the examples section that shows this behavior and adds a test.