### PR TITLE
add application_name variable

### DIFF
--- a/magicgui/application.py
+++ b/magicgui/application.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from magicgui.widgets._protocols import BaseApplicationBackend
 
 DEFAULT_BACKEND = "qt"
+APPLICATION_NAME = "magicgui"
 
 
 @contextmanager

--- a/magicgui/backends/_qtpy/application.py
+++ b/magicgui/backends/_qtpy/application.py
@@ -1,10 +1,12 @@
-from qtpy.QtCore import QTimer
+import sys
+
+from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QApplication
 
+from magicgui.application import APPLICATION_NAME
 from magicgui.widgets._protocols import BaseApplicationBackend
 
 
-# qt implementation
 class ApplicationBackend(BaseApplicationBackend):
     _app: QApplication
 
@@ -19,7 +21,7 @@ class ApplicationBackend(BaseApplicationBackend):
     def _mgui_run(self):
         app = self._mgui_get_native_app()
         # only start the event loop if magicgui created it
-        if app.objectName() == "magicgui":
+        if app.applicationName() == APPLICATION_NAME:
             return app.exec_()
 
     def _mgui_quit(self):
@@ -29,8 +31,9 @@ class ApplicationBackend(BaseApplicationBackend):
         # Get native app
         self._app = QApplication.instance()
         if not self._app:
-            self._app = QApplication([])
-            self._app.setObjectName("magicgui")
+            QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+            self._app = QApplication(sys.argv)
+            self._app.setApplicationName(APPLICATION_NAME)
         return self._app
 
     def _mgui_start_timer(self, interval=0, on_timeout=None, single=False):

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -312,9 +312,9 @@ class BaseApplicationBackend(ABC):
     def _mgui_quit(self):
         """Quit the native GUI event loop."""
 
+    @abstractmethod
     def _mgui_get_native_app(self):
         """Return the native GUI application instance."""
-        return self
 
     @abstractmethod
     def _mgui_start_timer(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,7 @@
+from magicgui import use_app
+from magicgui.application import APPLICATION_NAME
+
+
+def test_app_name():
+    app = use_app("qt")
+    assert app.native.applicationName() == APPLICATION_NAME


### PR DESCRIPTION
adds a variable `magicgui.application.APPLICATION_NAME` that all backends must use to name their app.