### PR TITLE
Enable decorator to be used on methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-docstrings]
         pass_filenames: true
         exclude: examples
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/examples/class_method.py
+++ b/examples/class_method.py
@@ -1,0 +1,29 @@
+"""Demonstrates decorating a method.
+
+Once the class is instantiated, `instance.method_name` will return a FunctionGui
+in which the instance will always be provided as the first argument (i.e. "self") when
+the FunctionGui or method is called.
+"""
+from magicgui import event_loop, magicgui
+from magicgui.widgets import Container
+
+
+class MyObject:
+    def __init__(self, name):
+        self.name = name
+        self.counter = 0.0
+
+    @magicgui(auto_call=True)
+    def method(self, sigma: float = 0):
+        print(f"instance: {self.name}, counter: {self.counter}, sigma: {sigma}")
+        self.counter = self.counter + sigma
+        return self.name
+
+
+with event_loop():
+    a = MyObject("a")
+    b = MyObject("b")
+    container = Container(widgets=[a.method, b.method])
+    container.show()
+    assert a.method() == "a"
+    assert b.method() == "b"

--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -250,7 +250,6 @@ class FunctionGui(Container):
 
         Example
         -------
-
         >>> class MyClass:
         ...     @magicgui
         ...     def my_method(self, x=1):
@@ -258,11 +257,9 @@ class FunctionGui(Container):
         ...
         >>> c = MyClass()
         >>> c.my_method  # the FunctionGui that can be used as a widget
-        >>> c.my_method(34)  # calling it works as usual, with `c` provided as `self`
+        >>> c.my_method(x=34)  # calling it works as usual, with `c` provided as `self`
         {'self': <__main__.MyClass object at 0x7fb610e455e0>, 'x': 34}
-
         """
-
         if obj is not None:
             if id(obj) not in self._instance_guis:
                 method = getattr(obj.__class__, self._function.__name__)
@@ -272,6 +269,7 @@ class FunctionGui(Container):
         return self
 
     def __set__(self, obj, value):
+        """Prevent setting a magicgui attribute."""
         raise AttributeError("Can't set magicgui attribute")
 
     def Gui(self, show=False):

--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from typing import Any, Callable, Dict, Optional, TypeVar, Union, overload
+from typing import Any, Callable, Dict, Optional, Sequence, TypeVar, Union, overload
 
 from magicgui.application import AppRef
 from magicgui.events import EventEmitter
@@ -118,15 +118,35 @@ class FunctionGui(Container):
         if show:
             self.show()
 
-    def bind(self, kwargs):
+    def bind(self, kwargs: dict):
+        """Bind key/value pairs to the function signature.
+
+        Values supplied here will be permanently bound to the corresponding parameters:
+        their widgets will be hidden from the GUI and the value will be used for the
+        corresponding parameter when the function is called.
+
+        Parameters
+        ----------
+        kwargs :  dict, optional
+            A mapping of parameter names to values to bind.
+        """
         self._bound.update(kwargs)
         for name, value in kwargs.items():
             getattr(self, name).hide()
 
-    def unbind(self, args):
+    def unbind(self, args: Sequence):
+        """Unbind keys from the function signature.
+
+        Parameters
+        ----------
+        args : sequence
+            A sequence of parameter names.  If any are currently bound to a value, the
+            binding will be cleared and the widget will be shown.
+        """
         for name in args:
-            del self._bound[name]
-            getattr(self, name).show()
+            if name in self._bound:
+                del self._bound[name]
+                getattr(self, name).show()
 
     def __getattr__(self, value):
         """Catch deprecated _name_changed attribute."""

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -855,7 +855,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
 
     @property
     def orientation(self):
-        """Return the orientation of the widget"""
+        """Return the orientation of the widget."""
         return self._orientation
 
     @orientation.setter

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -738,6 +738,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
         **kwargs,
     ):
         self.labels = labels
+        self._orientation = orientation
         kwargs["backend_kwargs"] = {"orientation": orientation}
         super().__init__(**kwargs)
         self.changed = EventEmitter(source=self, type="changed")
@@ -851,6 +852,17 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
     def margins(self, margins: Tuple[int, int, int, int]) -> None:
         # left, top, right, bottom
         self._widget._mgui_set_margins(margins)
+
+    @property
+    def orientation(self):
+        """Return the orientation of the widget"""
+        return self._orientation
+
+    @orientation.setter
+    def orientation(self, value):
+        raise NotImplementedError(
+            "It is not yet possible to change orientation after instantiation"
+        )
 
     @property
     def native_layout(self):

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -443,3 +443,23 @@ def test_register_return_callback():
 #     """Test that setting MagicGui parent emits a signal."""
 #     with qtbot.waitSignal(magic_func.parent_changed, timeout=1000):
 #         magic_func.native.setParent(None)
+
+
+def test_function_binding():
+    class MyObject:
+        def __init__(self, name):
+            self.name = name
+            self.counter = 0.0
+
+        @magicgui(auto_call=True)
+        def method(self, sigma: float = 1):
+            self.counter = self.counter + sigma
+            return self.name, self.counter
+
+    a = MyObject("a")
+    b = MyObject("b")
+
+    assert a.method() == ("a", 1)
+    assert b.method(sigma=4) == ("b", 4)
+    assert a.method() == ("a", 2)
+    assert b.method() == ("b", 5)


### PR DESCRIPTION
closes #53 by enabling `@magicgui` decorator on class methods:
```python
class MyObject:
    def __init__(self):
        self.counter = 0

    @magicgui(auto_call=True)
    def process_image(self, sigma: float = 5):
        self.counter = self.counter + sigma
        print(self)

m = MyObject()
m.process_image  # This a FunctionGui with `m` bound to `self` when calling the method.
```
(see also: `examples/class_method.py `)

This works by adding a `__get__` method to the `FunctionGui` class, making it a [descriptor](https://docs.python.org/3/howto/descriptor.html#descriptor-protocol) that will pass the instance from which it is called as the first argument when calling the method.