### PR TITLE
API cleanup and unify with ipywidgets (a little)

### DIFF
--- a/docs/examples/napari/napari_parameter_sweep.md
+++ b/docs/examples/napari/napari_parameter_sweep.md
@@ -61,7 +61,7 @@ with napari.gui_qt():
     # - we contstrain the possible choices for `mode`
     @magicgui(
         auto_call=True,
-        sigma={"widget_type": "FloatSlider", "maximum": 6},
+        sigma={"widget_type": "FloatSlider", "max": 6},
         mode={"choices": ["reflect", "constant", "nearest", "mirror", "wrap"]},
     )
     def gaussian_blur(layer: Image, sigma: float = 1.0, mode="nearest") -> Image:
@@ -116,7 +116,7 @@ Finally, we decorate the function with `@magicgui` and provide some options.
 ```python
 @magicgui(
     auto_call=True,
-    sigma={"widget_type": "FloatSlider", "maximum": 6},
+    sigma={"widget_type": "FloatSlider", "max": 6},
     mode={"choices": ["reflect", "constant", "nearest", "mirror", "wrap"]},
 )
 def gaussian_blur(layer: Image, sigma: float = 1.0, mode="nearest") -> Image:

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -209,8 +209,8 @@ from magicgui.widgets import Label
 def add(a=2, b=3):
     return a + b
 
-add.insert(1, Label(default="+"))
-add.insert(3, Label(default="="))
+add.insert(1, Label(value="+"))
+add.insert(3, Label(value="="))
 add()
 add.show()
 ```

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -111,7 +111,7 @@ the call to `magicgui` with the same name as the parameter in the signature that
 you want to modify:
 
 ```{code-cell} python
-@magicgui(b={'minimum': 10, 'maximum': 20})
+@magicgui(b={'min': 10, 'max': 20})
 def add(a: int, b: int = 15) -> int:
     return a + b
 
@@ -123,14 +123,14 @@ The keys in the parameter-specific options dict must be valid arguments
 for the corresponding widget type from {mod}`magicgui.widgets`.  In this
 example, the `a_string` paremeter would be turned into a
 {class}`~magicgui.widgets.LineEdit` widget, which does not take an
-argument "`minimum`":
+argument "`min`":
 ```
 
 ```{code-cell} python
 ---
 tags: [raises-exception]
 ---
-@magicgui(a_string={'minimum': 10})
+@magicgui(a_string={'min': 10})
 def whoops(a_string: str = 'Hi there'):
     ...
 ```
@@ -144,7 +144,7 @@ widget in [magicgui.widgets](magicgui.widgets).  Or an actual
 `int` into a slider:
 
 ```{code-cell} python
-@magicgui(b={'widget_type': 'Slider', 'minimum': 10, 'maximum': 20})
+@magicgui(b={'widget_type': 'Slider', 'min': 10, 'max': 20})
 def add(a: int, b: int = 15) -> int:
     return a + b
 

--- a/docs/usage/direct_api.md
+++ b/docs/usage/direct_api.md
@@ -27,9 +27,9 @@ from magicgui.widgets import SpinBox, FileEdit, Slider, Label, Container
 from pathlib import Path
 
 # make some widgets
-spin_box = SpinBox(default=10, name='spin', label='Value:', maximum=100)
+spin_box = SpinBox(default=10, name='spin', label='Value:', max=100)
 file_picker = FileEdit(default='some/path')
-slider = Slider(default=30, minimum=20, maximum=40)
+slider = Slider(default=30, min=20, max=40)
 label = Label(default=slider.value)
 
 # set up callbacks

--- a/docs/usage/direct_api.md
+++ b/docs/usage/direct_api.md
@@ -27,10 +27,10 @@ from magicgui.widgets import SpinBox, FileEdit, Slider, Label, Container
 from pathlib import Path
 
 # make some widgets
-spin_box = SpinBox(default=10, name='spin', label='Value:', max=100)
-file_picker = FileEdit(default='some/path')
-slider = Slider(default=30, min=20, max=40)
-label = Label(default=slider.value)
+spin_box = SpinBox(value=10, name='spin', label='Value:', max=100)
+file_picker = FileEdit(value='some/path')
+slider = Slider(value=30, min=20, max=40)
+label = Label(value=slider.value)
 
 # set up callbacks
 def set_label(event):
@@ -51,6 +51,6 @@ list:
 ```python
 container.remove(file_picker)
 container.pop(0)
-container.insert(2, Label(default='a new label'))
+container.insert(2, Label(value='a new label'))
 container.show()
 ```

--- a/examples/OLD_napari_param_sweep.py
+++ b/examples/OLD_napari_param_sweep.py
@@ -27,7 +27,7 @@ with napari.gui_qt():
         auto_call=True,
         # "fixedWidth" is qt specific and no longer works
         # this will eventually raise an exception
-        sigma={"widget_type": QDoubleSlider, "maximum": 6, "fixedWidth": 400},
+        sigma={"widget_type": QDoubleSlider, "max": 6, "fixedWidth": 400},
         mode={"choices": ["reflect", "constant", "nearest", "mirror", "wrap"]},
     )
     def gaussian_blur(layer: Image, sigma: float = 1.0, mode="nearest") -> Image:

--- a/examples/forward_refs.py
+++ b/examples/forward_refs.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import napari
 
 
-@magicgui(call_button="execute", background={"maximum": 200})
+@magicgui(call_button="execute", background={"max": 200})
 def subtract_background(
     layerA: "napari.layers.Image", background: int = 50
 ) -> "napari.layers.Image":

--- a/examples/log_slider.py
+++ b/examples/log_slider.py
@@ -5,7 +5,7 @@ from magicgui import magicgui
 @magicgui(
     auto_call=True,
     result_widget=True,
-    input={"widget_type": "LogSlider", "maximum": 10000, "minimum": 1},
+    input={"widget_type": "LogSlider", "max": 10000, "min": 1},
 )
 def slider(input=1):
     return round(input, 4)

--- a/examples/napari_param_sweep.py
+++ b/examples/napari_param_sweep.py
@@ -25,7 +25,7 @@ with napari.gui_qt():
     # - we contstrain the possible choices for `mode`
     @magicgui(
         auto_call=True,
-        sigma={"widget_type": "FloatSlider", "maximum": 6},
+        sigma={"widget_type": "FloatSlider", "max": 6},
         mode={"choices": ["reflect", "constant", "nearest", "mirror", "wrap"]},
     )
     def gaussian_blur(layer: Image, sigma: float = 1.0, mode="nearest") -> Image:

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -149,19 +149,19 @@ class QBaseRangedWidget(QBaseValueWidget, _protocols.RangedWidgetProtocol):
     def __init__(self, qwidg):
         super().__init__(qwidg, "value", "setValue", "valueChanged")
 
-    def _mgui_get_minimum(self) -> float:
+    def _mgui_get_min(self) -> float:
         """Get the minimum possible value."""
         return self._qwidget.minimum()
 
-    def _mgui_set_minimum(self, value: float):
+    def _mgui_set_min(self, value: float):
         """Set the minimum possible value."""
         self._qwidget.setMinimum(value)
 
-    def _mgui_get_maximum(self) -> float:
+    def _mgui_get_max(self) -> float:
         """Set the maximum possible value."""
         return self._qwidget.maximum()
 
-    def _mgui_set_maximum(self, value: float):
+    def _mgui_set_max(self, value: float):
         """Set the maximum possible value."""
         self._qwidget.setMaximum(value)
 

--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -77,7 +77,7 @@ class FunctionGui(Container):
     ):
         bind = bind or dict()
         # consume extra Widget keywords
-        extra = set(kwargs) - set(["kind", "default", "annotation", "gui_only"])
+        extra = set(kwargs) - set(["kind", "annotation", "gui_only"])
         if extra:
             s = "s" if len(extra) > 1 else ""
             raise TypeError(f"FunctionGui got unexpected keyword argument{s}: {extra}")

--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -77,7 +77,7 @@ class FunctionGui(Container):
     ):
         bind = bind or dict()
         # consume extra Widget keywords
-        extra = set(kwargs) - set(["kind", "annotation", "gui_only"])
+        extra = set(kwargs) - set(["annotation", "gui_only"])
         if extra:
             s = "s" if len(extra) > 1 else ""
             raise TypeError(f"FunctionGui got unexpected keyword argument{s}: {extra}")

--- a/magicgui/signature.py
+++ b/magicgui/signature.py
@@ -135,21 +135,22 @@ class MagicParameter(inspect.Parameter):
 
         value = None if self.default is self.empty else self.default
         annotation, options = split_annotated_type(self.annotation)
-        return create_widget(
+        widget = create_widget(
             name=self.name,
-            kind=self.kind.name,
             value=value,
             annotation=annotation,
             app=app,
             options=options,
         )
+        widget.param_kind = self.kind
+        return widget
 
     @classmethod
     def from_widget(cls, widget: "Widget") -> MagicParameter:
         """Create a MagicParameter object representing a widget."""
         return cls(
             name=str(widget.name),
-            kind=widget.kind,
+            kind=widget.param_kind,
             default=getattr(widget, "value", None),
             annotation=widget.annotation,
             gui_options=widget.options,

--- a/magicgui/signature.py
+++ b/magicgui/signature.py
@@ -85,7 +85,7 @@ class MagicParameter(inspect.Parameter):
         The :attr:`inspect.Parameter.kind` represented by this widget.  Used in building
         signatures from multiple widgets, by default "POSITIONAL_OR_KEYWORD"
     default : Any, optional
-        The default & starting value for the widget, by default None
+        The default value for the parameter, by default None
     annotation : Any, optional
         The type annotation for the parameter represented by the widget, by default
         None
@@ -138,7 +138,7 @@ class MagicParameter(inspect.Parameter):
         return create_widget(
             name=self.name,
             kind=self.kind.name,
-            default=value,
+            value=value,
             annotation=annotation,
             app=app,
             options=options,

--- a/magicgui/types.py
+++ b/magicgui/types.py
@@ -72,8 +72,8 @@ class WidgetOptions(TypedDict, total=False):
     visible: bool
     enabled: bool
     text: str
-    minimum: float
-    maximum: float
+    min: float
+    max: float
     step: float
     orientation: str
     mode: Union[str, FileDialogMode]

--- a/magicgui/widgets/__init__.py
+++ b/magicgui/widgets/__init__.py
@@ -9,6 +9,8 @@ to the function.
 
 """
 
+from functools import partial
+
 from ._bases import Widget, create_widget
 from ._concrete import (
     CheckBox,
@@ -30,6 +32,24 @@ from ._concrete import (
     SpinBox,
     TextEdit,
 )
+
+#: Aliases for compatibility with ipywidgets.  (WIP)
+IntSlider = Slider
+FloatLogSlider = LogSlider
+IntText = SpinBox
+BoundedIntText = SpinBox
+FloatText = FloatSpinBox
+BoundedFloatText = FloatSpinBox
+ToggleButton = RadioButton
+Checkbox = CheckBox
+Dropdown = ComboBox
+Text = LineEdit
+Textarea = TextEdit
+Combobox = ComboBox
+DatePicker = DateTimeEdit
+Box = Container
+HBox = partial(Container, orientation="horizontal")
+VBox = partial(Container, orientation="vertical")
 
 __all__ = [
     "CheckBox",
@@ -53,3 +73,5 @@ __all__ = [
     "TextEdit",
     "Widget",
 ]
+
+del partial

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -89,7 +89,7 @@ def create_widget(
     """Create and return appropriate widget subclass.
 
     This factory function can be used to create a widget appropriate for the
-    provided `value` and/or `annotation` provided.
+    provided ``value`` and/or ``annotation`` provided.
 
     Parameters
     ----------
@@ -105,9 +105,10 @@ def create_widget(
         signatures from multiple widgets, by default "``POSITIONAL_OR_KEYWORD``"
     label : str
         A string to use for an associated Label widget (if this widget is being
-        shown in a `Container` widget, and labels are on).  By default, `name` will
-        be used. Note: `name` refers the name of the parameter, as might be used in
-        a signature, whereas label is just the label for that widget in the GUI.
+        shown in a :class:`~magicgui.widgets.Container` widget, and labels are on).
+        By default, ``name`` will be used. Note: ``name`` refers the name of the
+        parameter, as might be used in a signature, whereas label is just the label
+        for that widget in the GUI.
     gui_only : bool, optional
         Whether the widget should be considered "only for the gui", or if it should
         be included in any widget container signatures, by default False
@@ -182,11 +183,11 @@ class Widget:
         The type annotation for the parameter represented by the widget, by default
         ``None``
     label : str
-        A string to use for an associated Label widget (if this widget is being shown in
-        a `Container` widget, and labels are on).  By default, `name` will be used.
-        Note: `name` refers the name of the parameter, as might be used in a signature,
-        whereas label is just the label for that widget in the GUI.
-    gui_only : bool, optional
+        A string to use for an associated Label widget (if this widget is being
+        shown in a :class:`~magicgui.widgets.Container` widget, and labels are on).
+        By default, ``name`` will be used. Note: ``name`` refers the name of the
+        parameter, as might be used in a signature, whereas label is just the label
+        for that widget in the GUI.
         Whether the widget should be considered "only for the gui", or if it should be
         included in any widget container signatures, by default False
     backend_kwargs : dict, optional
@@ -403,7 +404,7 @@ class ButtonWidget(ValueWidget):
     Parameters
     ----------
     text : str, optional
-        The text to display on the button. If not provided, will use `name`.
+        The text to display on the button. If not provided, will use ``name``.
     """
 
     _widget: _protocols.ButtonWidgetProtocol
@@ -500,8 +501,8 @@ class TransformedRangedWidget(RangedWidget, ABC):
     """Widget with a contstrained value. Wraps RangedWidgetProtocol.
 
     This can be used to map one domain of numbers onto another, useful for creating
-    things like LogSliders.  Subclasses must reimplement `_value_from_position` and
-    `_position_from_value`.
+    things like LogSliders.  Subclasses must reimplement ``_value_from_position`` and
+    ``_position_from_value``.
 
     Parameters
     ----------
@@ -856,7 +857,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
         return d
 
     def insert(self, key: int, widget: Widget):
-        """Insert widget at `key`."""
+        """Insert widget at ``key``."""
         if isinstance(widget, ValueWidget):
             widget.changed.connect(lambda x: self.changed(value=self))
         self._widget._mgui_insert_widget(key, widget)

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -412,9 +412,9 @@ class RangedWidget(ValueWidget):
 
     Parameters
     ----------
-    minimum : float, optional
+    min : float, optional
         The minimum allowable value, by default 0
-    maximum : float, optional
+    max : float, optional
         The maximum allowable value, by default 100
     step : float, optional
         The step size for incrementing the value, by default 1
@@ -422,39 +422,37 @@ class RangedWidget(ValueWidget):
 
     _widget: _protocols.RangedWidgetProtocol
 
-    def __init__(
-        self, minimum: float = 0, maximum: float = 100, step: float = 1, **kwargs
-    ):
+    def __init__(self, min: float = 0, max: float = 100, step: float = 1, **kwargs):
         super().__init__(**kwargs)
 
-        self.minimum = minimum
-        self.maximum = maximum
+        self.min = min
+        self.max = max
         self.step = step
 
     @property
     def options(self) -> dict:
         """Return options currently being used in this widget."""
         d = super().options.copy()
-        d.update({"minimum": self.minimum, "maximum": self.maximum, "step": self.step})
+        d.update({"min": self.min, "max": self.max, "step": self.step})
         return d
 
     @property
-    def minimum(self) -> float:
+    def min(self) -> float:
         """Minimum allowable value for the widget."""
-        return self._widget._mgui_get_minimum()
+        return self._widget._mgui_get_min()
 
-    @minimum.setter
-    def minimum(self, value: float):
-        self._widget._mgui_set_minimum(value)
+    @min.setter
+    def min(self, value: float):
+        self._widget._mgui_set_min(value)
 
     @property
-    def maximum(self) -> float:
+    def max(self) -> float:
         """Maximum allowable value for the widget."""
-        return self._widget._mgui_get_maximum()
+        return self._widget._mgui_get_max()
 
-    @maximum.setter
-    def maximum(self, value: float):
-        self._widget._mgui_set_maximum(value)
+    @max.setter
+    def max(self, value: float):
+        self._widget._mgui_set_max(value)
 
     @property
     def step(self) -> float:
@@ -468,11 +466,11 @@ class RangedWidget(ValueWidget):
     @property
     def range(self) -> Tuple[float, float]:
         """Range of allowable values for the widget."""
-        return self.minimum, self.maximum
+        return self.min, self.max
 
     @range.setter
     def range(self, value: Tuple[float, float]):
-        self.minimum, self.maximum = value
+        self.min, self.max = value
 
 
 class TransformedRangedWidget(RangedWidget, ABC):
@@ -484,9 +482,9 @@ class TransformedRangedWidget(RangedWidget, ABC):
 
     Parameters
     ----------
-    minimum : float, optional
+    min : float, optional
         The minimum allowable value, by default 0
-    maximum : float, optional
+    max : float, optional
         The maximum allowable value, by default 100
     min_pos : float, optional
         The minimum value for the *internal* (widget) position, by default 0.
@@ -500,21 +498,21 @@ class TransformedRangedWidget(RangedWidget, ABC):
 
     def __init__(
         self,
-        minimum: float = 0,
-        maximum: float = 100,
+        min: float = 0,
+        max: float = 100,
         min_pos: int = 0,
         max_pos: int = 100,
         step: int = 1,
         **kwargs,
     ):
-        self._minimum = minimum
-        self._maximum = maximum
+        self._min = min
+        self._max = max
         self._min_pos = min_pos
         self._max_pos = max_pos
         ValueWidget.__init__(self, **kwargs)
 
-        self._widget._mgui_set_minimum(self._min_pos)
-        self._widget._mgui_set_maximum(self._max_pos)
+        self._widget._mgui_set_min(self._min_pos)
+        self._widget._mgui_set_max(self._max_pos)
         self._widget._mgui_set_step(step)
 
     # Just a linear scaling example.
@@ -523,17 +521,17 @@ class TransformedRangedWidget(RangedWidget, ABC):
     @property
     def _scale(self):
         """Slope of a linear map.  Just used as an example."""
-        return (self.maximum - self.minimum) / (self._max_pos - self._min_pos)
+        return (self.max - self.min) / (self._max_pos - self._min_pos)
 
     @abstractmethod
     def _value_from_position(self, position):
         """Return 'real' value given internal widget position."""
-        return self.minimum + self._scale * (position - self._min_pos)
+        return self.min + self._scale * (position - self._min_pos)
 
     @abstractmethod
     def _position_from_value(self, value):
         """Return internal widget position given 'real' value."""
-        return (value - self.minimum) / self._scale + self._min_pos
+        return (value - self.min) / self._scale + self._min_pos
 
     #########
 
@@ -547,25 +545,25 @@ class TransformedRangedWidget(RangedWidget, ABC):
         return self._widget._mgui_set_value(self._position_from_value(value))
 
     @property
-    def minimum(self) -> float:
+    def min(self) -> float:
         """Minimum allowable value for the widget."""
-        return self._minimum
+        return self._min
 
-    @minimum.setter
-    def minimum(self, value: float):
+    @min.setter
+    def min(self, value: float):
         prev = self.value
-        self._minimum = value
+        self._min = value
         self.value = prev
 
     @property
-    def maximum(self) -> float:
+    def max(self) -> float:
         """Maximum allowable value for the widget."""
-        return self._maximum
+        return self._max
 
-    @maximum.setter
-    def maximum(self, value: float):
+    @max.setter
+    def max(self, value: float):
         prev = self.value
-        self._maximum = value
+        self._max = value
         self.value = prev
 
 

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -204,7 +204,6 @@ class Widget:
         **extra,
     ):
         if extra:
-
             warnings.warn(
                 f"\n\n{self.__class__.__name__}.__init__() got unexpected "
                 f"keyword arguments {set(extra)!r}.\n"

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -203,6 +203,8 @@ class Widget:
         backend_kwargs=dict(),
         **extra,
     ):
+        # for ipywidgets API compatibility
+        label = label or extra.pop("description", None)
         if extra:
             warnings.warn(
                 f"\n\n{self.__class__.__name__}.__init__() got unexpected "

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -342,9 +342,9 @@ class RangeEdit(Container):
     """
 
     def __init__(self, start=0, stop=10, step=1, **kwargs):
-        self.start = SpinBox(default=start)
-        self.stop = SpinBox(default=stop)
-        self.step = SpinBox(default=step)
+        self.start = SpinBox(value=start)
+        self.stop = SpinBox(value=stop)
+        self.step = SpinBox(value=step)
         kwargs["widgets"] = [self.start, self.stop, self.step]
         super().__init__(**kwargs)
 

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -256,7 +256,7 @@ class FileEdit(Container):
     def __init__(
         self, mode: FileDialogMode = FileDialogMode.EXISTING_FILE, filter=None, **kwargs
     ):
-        self.line_edit = LineEdit()
+        self.line_edit = LineEdit(value=kwargs.pop("value", None))
         self.choose_btn = PushButton()
         self.mode = mode  # sets the button text too
         self.filter = filter

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -188,30 +188,30 @@ class LogSlider(TransformedRangedWidget):
     """
 
     def __init__(
-        self, minimum: float = 1, maximum: float = 100, base: float = math.e, **kwargs
+        self, min: float = 1, max: float = 100, base: float = math.e, **kwargs
     ):
         self._base = base
         app = use_app()
         assert app.native
         super().__init__(
-            minimum=minimum,
-            maximum=maximum,
+            min=min,
+            max=max,
             widget_type=app.get_obj("Slider"),
             **kwargs,
         )
 
     @property
     def _scale(self):
-        minv = math.log(self.minimum, self.base)
-        maxv = math.log(self.maximum, self.base)
+        minv = math.log(self.min, self.base)
+        maxv = math.log(self.max, self.base)
         return (maxv - minv) / (self._max_pos - self._min_pos)
 
     def _value_from_position(self, position):
-        minv = math.log(self.minimum, self.base)
+        minv = math.log(self.min, self.base)
         return math.pow(self.base, minv + self._scale * (position - self._min_pos))
 
     def _position_from_value(self, value):
-        minv = math.log(self.minimum, self.base)
+        minv = math.log(self.min, self.base)
         return (math.log(value, self.base) - minv) / self._scale + self._min_pos
 
     @property

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -93,22 +93,22 @@ class RangedWidgetProtocol(ValueWidgetProtocol, Protocol):
     """Value widget that supports numbers within a provided min/max range."""
 
     @abstractmethod
-    def _mgui_get_minimum(self) -> float:
+    def _mgui_get_min(self) -> float:
         """Get the minimum possible value."""
         raise NotImplementedError()
 
     @abstractmethod
-    def _mgui_set_minimum(self, value: float) -> None:
+    def _mgui_set_min(self, value: float) -> None:
         """Set the minimum possible value."""
         raise NotImplementedError()
 
     @abstractmethod
-    def _mgui_get_maximum(self) -> float:
+    def _mgui_get_max(self) -> float:
         """Get the maximum possible value."""
         raise NotImplementedError()
 
     @abstractmethod
-    def _mgui_set_maximum(self, value: float) -> None:
+    def _mgui_set_max(self, value: float) -> None:
         """Set the maximum possible value."""
         raise NotImplementedError()
 

--- a/magicgui/widgets/_transforms.py
+++ b/magicgui/widgets/_transforms.py
@@ -34,7 +34,7 @@ def transform_get_set(
         )
     suffixes = ["value"]
     if issubclass(cls, RangedWidgetProtocol):
-        suffixes.extend(["maximum", "minimum", "step"])
+        suffixes.extend(["max", "min", "step"])
 
     new_cls = type(f"{prefix}{cls.__name__}", (cls,), {"__module__": __name__})
     for suffix in suffixes:

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -158,7 +158,7 @@ def test_changing_widget_attr_fails(magic_func):
     assert isinstance(widget1, widgets.LineEdit)
 
     # changing it to a different type will destroy and create a new widget
-    widget2 = widgets.create_widget(default=1, name="a")
+    widget2 = widgets.create_widget(value=1, name="a")
     with pytest.raises(AttributeError):
         magic_func.a = widget2
 


### PR DESCRIPTION
This changes some things I didn't like about the widget API (like using `Widget(default='starting value')` instead of `Widget(value='starting value')` ... "default" fit with the `inspect.Parameter` parallel, but doesn't feel right for a widget.)  It also removes some of the excess parameters from `__init__`.

It also makes a couple parameters the same as in ipywidgets (like "min/max" instead of "minimum/maximum" ... I can't imagine when shadowing the builtin there is going to matter?).  I stopped short of renaming all of the widgets, but I did create a bunch of aliases in `magicgui.widgets` to the corresponding widgets in ipywidgets... so it should be _close_ to possible to use the same API (haven't tested much yet, and probably won't for a while)