### PR TITLE
resolve ForwardRef on widget.annotation

### DIFF
--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -53,6 +53,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ForwardRef,
     List,
     MutableSequence,
     Optional,
@@ -229,7 +230,8 @@ class Widget:
         self.name: str = name
         self.param_kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
         self._label = label
-        self.annotation: Any = annotation
+        self.annotation = annotation
+
         self.gui_only = gui_only
         self.visible: bool = True
         self.parent_changed = EventEmitter(source=self, type="parent_changed")
@@ -243,6 +245,22 @@ class Widget:
         self._post_init()
         if not visible:
             self.hide()
+
+    @property
+    def annotation(self):
+        """Return type annotation for the parameter represented by the widget.
+
+        ForwardRefs will be resolve when setting the annotation.
+        """
+        return self._annotation
+
+    @annotation.setter
+    def annotation(self, value):
+        if isinstance(value, ForwardRef):
+            from magicgui.type_map import _evaluate_forwardref
+
+            value = _evaluate_forwardref(value)
+        self._annotation = value
 
     @property
     def param_kind(self) -> inspect._ParameterKind:

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -230,8 +230,7 @@ class Widget:
         self.name: str = name
         self.param_kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
         self._label = label
-        self.annotation = annotation
-
+        self.annotation: Any = annotation
         self.gui_only = gui_only
         self.visible: bool = True
         self.parent_changed = EventEmitter(source=self, type="parent_changed")

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,4 +1,5 @@
 import pytest
+from tests import MyInt
 
 from magicgui import magicgui, widgets
 
@@ -33,3 +34,13 @@ def test_delete_widget():
     # they disappear from the layout
     with pytest.raises(ValueError):
         container.index(a)
+
+
+def test_widget_resolves_forward_ref():
+    """The annotation on a widget should always be a resolved type."""
+
+    @magicgui
+    def widget(x: "tests.MyInt"):  # type: ignore  # noqa
+        pass
+
+    assert widget.x.annotation is MyInt


### PR DESCRIPTION
closes #65 
I think this is probably the right thing to do... We will have already tried to resolve any forward ref annotations when creating widgets, so it should already be in `sys.modules` and we might as well store the resolved type on `widget.annotation` for the convenience of others.