### PR TITLE
Change "orientation" on containers to "layout"

### DIFF
--- a/docs/examples/widget_demo.md
+++ b/docs/examples/widget_demo.md
@@ -36,7 +36,7 @@ class Medium(Enum):
 
 @magicgui(
     call_button="Calculate",
-    orientation="vertical",
+    layout="vertical",
     result_widget=True,
     # numbers default to spinbox widgets, but we can make
     # them sliders using the `widget_type` option

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -84,14 +84,14 @@ add.a.value = 4
 add.show()
 ```
 
-### `orientation`
+### `layout`
 
-The `orientation` option determines the orientation of the layout.
+The `layout` option determines the layout of the layout.
 Currently, only `horizontal`, `vertical` are supported. Grid Layouts are a work
 in progress...
 
 ```{code-cell} python
-@magicgui(orientation='vertical', call_button='Add')
+@magicgui(layout='vertical', call_button='Add')
 def add(a: int, b: int) -> int:
     return a + b
 

--- a/examples/widget_demo.py
+++ b/examples/widget_demo.py
@@ -18,7 +18,7 @@ class Medium(Enum):
 
 @magicgui(
     call_button="Calculate",
-    orientation="vertical",
+    layout="vertical",
     result_widget=True,
     slider_float={"widget_type": "FloatSlider"},
     filename={"label": "Pick a file:"},

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -231,9 +231,9 @@ class RadioButton(QBaseButtonWidget):
 class Container(
     QBaseWidget, _protocols.ContainerProtocol, _protocols.SupportsOrientation
 ):
-    def __init__(self, orientation="vertical"):
+    def __init__(self, layout="vertical"):
         QBaseWidget.__init__(self, QtW.QWidget)
-        if orientation == "horizontal":
+        if layout == "horizontal":
             self._layout: QtW.QLayout = QtW.QHBoxLayout()
         else:
             self._layout = QtW.QVBoxLayout()
@@ -283,14 +283,14 @@ class Container(
         return None
 
     def _mgui_set_orientation(self, value) -> None:
-        """Set orientation, value will be 'horizontal' or 'vertical'"""
+        """Set orientation, value will be 'horizontal' or 'vertical'."""
         raise NotImplementedError(
             "Sorry, changing orientation after instantiation "
             "is not yet implemented for Qt."
         )
 
     def _mgui_get_orientation(self) -> str:
-        """Set orientation, return either 'horizontal' or 'vertical'"""
+        """Set orientation, return either 'horizontal' or 'vertical'."""
         if isinstance(self, QtW.QHBoxLayout):
             return "horizontal"
         else:

--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -26,7 +26,7 @@ class FunctionGui(Container):
     call_button : bool or str, optional
         If True, create an additional button that calls the original function when
         clicked.  If a ``str``, set the button text. by default False
-    orientation : str, optional
+    layout : str, optional
         The type of layout to use. Must be one of {'horizontal', 'vertical'}.
         by default "horizontal".
     labels : bool, optional
@@ -64,7 +64,7 @@ class FunctionGui(Container):
         self,
         function: Callable,
         call_button: Union[bool, str] = False,
-        orientation: str = "horizontal",
+        layout: str = "horizontal",
         labels=True,
         app: AppRef = None,
         show: bool = False,
@@ -84,7 +84,7 @@ class FunctionGui(Container):
         self._function = function
         sig = magic_signature(function, gui_options=param_options)
         super().__init__(
-            orientation=orientation,
+            layout=layout,
             labels=labels,
             widgets=list(sig.widgets(app).values()),
             return_annotation=sig.return_annotation,
@@ -233,7 +233,7 @@ class FunctionGui(Container):
         return FunctionGui(
             function=self._function,
             call_button=bool(self._call_button),
-            orientation=self.orientation,
+            layout=self.layout,
             labels=self.labels,
             param_options=self._param_options,
             auto_call=self._auto_call,
@@ -311,7 +311,7 @@ def magicgui(function=None, **k) -> Callable[[F], FunctionGui]:  # noqa: D103
 def magicgui(
     function: Optional[F] = None,
     *,
-    orientation: str = "horizontal",
+    layout: str = "horizontal",
     labels: bool = True,
     call_button: Union[bool, str] = False,
     auto_call: bool = False,
@@ -327,7 +327,7 @@ def magicgui(
     function : Callable, optional
         The function to decorate.  Optional to allow bare decorator with optional
         arguments. by default ``None``
-    orientation : str, optional
+    layout : str, optional
         The type of layout to use. Must be one of {'horizontal', 'vertical'}.
         by default "horizontal".
     labels : bool, optional
@@ -388,7 +388,7 @@ def magicgui(
         func_gui = FunctionGui(
             function=func,
             call_button=call_button,
-            orientation=orientation,
+            layout=layout,
             labels=labels,
             param_options=param_options,
             auto_call=auto_call,

--- a/magicgui/types.py
+++ b/magicgui/types.py
@@ -75,5 +75,6 @@ class WidgetOptions(TypedDict, total=False):
     min: float
     max: float
     step: float
-    orientation: str
+    layout: str  # for things like containers
+    orientation: str  # for things like sliders
     mode: Union[str, FileDialogMode]

--- a/magicgui/widgets/__init__.py
+++ b/magicgui/widgets/__init__.py
@@ -48,8 +48,8 @@ Textarea = TextEdit
 Combobox = ComboBox
 DatePicker = DateTimeEdit
 Box = Container
-HBox = partial(Container, orientation="horizontal")
-VBox = partial(Container, orientation="vertical")
+HBox = partial(Container, layout="horizontal")
+VBox = partial(Container, layout="vertical")
 
 __all__ = [
     "CheckBox",

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -773,8 +773,8 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
 
     Parameters
     ----------
-    orientation : str, optional
-        The orientation for the container.  must be one of ``{'horizontal',
+    layout : str, optional
+        The layout for the container.  must be one of ``{'horizontal',
         'vertical'}``. by default "horizontal"
     widgets : Sequence[Widget], optional
         A sequence of widgets with which to intialize the container, by default
@@ -794,15 +794,15 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
 
     def __init__(
         self,
-        orientation: str = "horizontal",
+        layout: str = "horizontal",
         widgets: Sequence[Widget] = (),
         labels=True,
         return_annotation: Any = None,
         **kwargs,
     ):
         self._labels = labels
-        self._orientation = orientation
-        kwargs["backend_kwargs"] = {"orientation": orientation}
+        self._layout = layout
+        kwargs["backend_kwargs"] = {"layout": layout}
         super().__init__(**kwargs)
         self.changed = EventEmitter(source=self, type="changed")
         self._return_annotation = return_annotation
@@ -914,7 +914,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
     def _unify_label_widths(self, event=None):
         if not self._initialized:
             return
-        if self.orientation == "vertical" and self.labels:
+        if self.layout == "vertical" and self.labels:
             measure = use_app().get_obj("get_text_width")
             widest_label = max(
                 measure(w.label) for w in self if not isinstance(w, ButtonWidget)
@@ -935,14 +935,14 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
         self._widget._mgui_set_margins(margins)
 
     @property
-    def orientation(self) -> str:
-        """Return the orientation of the widget."""
-        return self._orientation
+    def layout(self) -> str:
+        """Return the layout of the widget."""
+        return self._layout
 
-    @orientation.setter
-    def orientation(self, value):
+    @layout.setter
+    def layout(self, value):
         raise NotImplementedError(
-            "It is not yet possible to change orientation after instantiation"
+            "It is not yet possible to change layout after instantiation"
         )
 
     @property

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -397,8 +397,8 @@ class _LabeledWidget(Container):
         position: str = "left",
         **kwargs,
     ):
-        orientation = "horizontal" if position in ("left", "right") else "vertical"
-        kwargs["backend_kwargs"] = {"orientation": orientation}
+        layout = "horizontal" if position in ("left", "right") else "vertical"
+        kwargs["backend_kwargs"] = {"layout": layout}
         self._inner_widget = widget
         self._label_widget = Label(value=label or widget.label)
         super().__init__(**kwargs)


### PR DESCRIPTION
Closes #63 and fixes #54 by reverting the `orientation` keyword on the magicgui function, and on `Container` widgets back to "layout"... as it will be more flexible moving forward with grid layouts