### PR TITLE
Fix parent_changed signal emission

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -3,7 +3,7 @@ from typing import Any, Iterable, Optional, Tuple, Union
 
 import qtpy
 from qtpy import QtWidgets as QtW
-from qtpy.QtCore import QEvent, QObject, Qt, QTimer, Signal
+from qtpy.QtCore import QEvent, QObject, Qt, Signal
 from qtpy.QtGui import QFont, QFontMetrics
 
 from magicgui.types import FileDialogMode
@@ -15,16 +15,9 @@ class EventFilter(QObject):
     parentChanged = Signal()
     valueChanged = Signal(object)
 
-    def eventFilter(self, obj, event):
+    def eventFilter(self, obj: QObject, event: QEvent):
         if event.type() == QEvent.ParentChange:
-            # FIXME: error prone... but we need this to emit AFTER the event is handled
-            def _try_emit():
-                try:
-                    self.parentChanged.emit()
-                except AttributeError:
-                    pass
-
-            QTimer().singleShot(0, _try_emit)
+            self.parentChanged.emit()
         return False
 
 

--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -83,6 +83,7 @@ class FunctionGui(Container):
             raise TypeError(f"FunctionGui got unexpected keyword argument{s}: {extra}")
         self._function = function
         sig = magic_signature(function, gui_options=param_options)
+        self._return_annotation = sig.return_annotation
         super().__init__(
             orientation=orientation,
             labels=labels,

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -235,15 +235,16 @@ class Widget:
         self.visible: bool = True
         self.parent_changed = EventEmitter(source=self, type="parent_changed")
         self.label_changed = EventEmitter(source=self, type="label_changed")
-        self._widget._mgui_bind_parent_change_callback(
-            lambda *x: self.parent_changed(value=self.parent)
-        )
+        self._widget._mgui_bind_parent_change_callback(self._emit_parent)
 
         # put the magicgui widget on the native object...may cause error on some backend
         self.native._magic_widget = self
         self._post_init()
         if not visible:
             self.hide()
+
+    def _emit_parent(self, event=None):
+        self.parent_changed(value=self.parent)
 
     @property
     def annotation(self):
@@ -807,6 +808,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
         self.changed = EventEmitter(source=self, type="changed")
         self._return_annotation = return_annotation
         self.extend(widgets)
+        self.parent_changed.connect(self.reset_choices)
         self._initialized = True
         self._unify_label_widths()
 

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -402,9 +402,12 @@ class _LabeledWidget(Container):
         self._inner_widget = widget
         self._label_widget = Label(value=label or widget.label)
         super().__init__(**kwargs)
+        self.parent_changed.disconnect()  # don't need _LabeledWidget to trigger stuff
         self.labels = False  # important to avoid infinite recursion during insert!
         self._inner_widget.label_changed.connect(self._on_label_change)
-        self.extend([self._label_widget, widget])
+        for w in [self._label_widget, widget]:
+            with w.parent_changed.blocker():
+                self.append(w)
         self.margins = (0, 0, 0, 0)
 
     def __repr__(self) -> str:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,7 +2,6 @@ import pytest
 from tests import MyInt
 
 from magicgui import magicgui, widgets
-from magicgui.application import use_app
 
 
 @pytest.mark.parametrize(
@@ -45,21 +44,3 @@ def test_widget_resolves_forward_ref():
         pass
 
     assert widget.x.annotation is MyInt
-
-
-def test_empty_widget():
-    """The annotation on a widget should always be a resolved type."""
-    use_app("qt")
-
-    @magicgui
-    def widget():
-        pass
-
-    from qtpy.QtCore import Qt
-    from qtpy.QtWidgets import QDockWidget, QMainWindow
-
-    main = QMainWindow()
-    dw = QDockWidget(main)
-    dw.setWidget(widget.native)
-    main.addDockWidget(Qt.RightDockWidgetArea, dw)
-    assert widget.native.parent() is dw

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,6 +2,7 @@ import pytest
 from tests import MyInt
 
 from magicgui import magicgui, widgets
+from magicgui.application import use_app
 
 
 @pytest.mark.parametrize(
@@ -44,3 +45,21 @@ def test_widget_resolves_forward_ref():
         pass
 
     assert widget.x.annotation is MyInt
+
+
+def test_empty_widget():
+    """The annotation on a widget should always be a resolved type."""
+    use_app("qt")
+
+    @magicgui
+    def widget():
+        pass
+
+    from qtpy.QtCore import Qt
+    from qtpy.QtWidgets import QDockWidget, QMainWindow
+
+    main = QMainWindow()
+    dw = QDockWidget(main)
+    dw.setWidget(widget.native)
+    main.addDockWidget(Qt.RightDockWidgetArea, dw)
+    assert widget.native.parent() is dw


### PR DESCRIPTION
This PR cleans up some of the `parent.changed` signal emission logic, and improves the event filter used to detect when a Qt Widget has had its parent changed