### PR TITLE
Resolve ForwardRefs on return annotations

### DIFF
--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -83,7 +83,6 @@ class FunctionGui(Container):
             raise TypeError(f"FunctionGui got unexpected keyword argument{s}: {extra}")
         self._function = function
         sig = magic_signature(function, gui_options=param_options)
-        self._return_annotation = sig.return_annotation
         super().__init__(
             layout=layout,
             labels=labels,
@@ -207,7 +206,7 @@ class FunctionGui(Container):
             with self._result_widget.changed.blocker():
                 self._result_widget.value = value
 
-        return_type = self._return_annotation
+        return_type = self.return_annotation
         if return_type:
             for callback in _type2callback(return_type):
                 callback(self, value, return_type)

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -255,7 +255,7 @@ class Widget:
 
     @annotation.setter
     def annotation(self, value):
-        if isinstance(value, ForwardRef):
+        if isinstance(value, (str, ForwardRef)):
             from magicgui.type_map import _evaluate_forwardref
 
             value = _evaluate_forwardref(value)
@@ -825,7 +825,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
 
     @return_annotation.setter
     def return_annotation(self, value):
-        if isinstance(value, ForwardRef):
+        if isinstance(value, (str, ForwardRef)):
             from magicgui.type_map import _evaluate_forwardref
 
             value = _evaluate_forwardref(value)

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -803,16 +803,33 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
         return_annotation: Any = None,
         **kwargs,
     ):
+        self._return_annotation = None
         self._labels = labels
         self._layout = layout
         kwargs["backend_kwargs"] = {"layout": layout}
         super().__init__(**kwargs)
         self.changed = EventEmitter(source=self, type="changed")
-        self._return_annotation = return_annotation
+        self.return_annotation = return_annotation
         self.extend(widgets)
         self.parent_changed.connect(self.reset_choices)
         self._initialized = True
         self._unify_label_widths()
+
+    @property
+    def return_annotation(self):
+        """Return annotation to use when converting to :class:`inspect.Signature`.
+
+        ForwardRefs will be resolve when setting the annotation.
+        """
+        return self._return_annotation
+
+    @return_annotation.setter
+    def return_annotation(self, value):
+        if isinstance(value, ForwardRef):
+            from magicgui.type_map import _evaluate_forwardref
+
+            value = _evaluate_forwardref(value)
+        self._return_annotation = value
 
     def __getattr__(self, name: str):
         """Return attribute ``name``.  Will return a widget if present."""
@@ -984,7 +1001,7 @@ class ContainerWidget(Widget, MutableSequence[Widget]):
         params = [
             MagicParameter.from_widget(w) for w in self if w.name and not w.gui_only
         ]
-        return MagicSignature(params, return_annotation=self._return_annotation)
+        return MagicSignature(params, return_annotation=self.return_annotation)
 
     @classmethod
     def from_signature(cls, sig: inspect.Signature, **kwargs) -> Container:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -52,4 +52,5 @@ def test_forward_refs_return_annotation():
     gui, result, return_annotation = results[0]
     assert isinstance(gui, FunctionGui)
     assert result == 1
-    assert return_annotation == "tests.MyInt"
+    # the forward ref has been resolved
+    assert return_annotation is MyInt


### PR DESCRIPTION
This PR also resolves ForwardRefs on return type annotations (#66 only handled ForwardRefs on parameter annotations).

I also changed it so that `register_type` immediately resolves any ForwardRefs.  It's unlikely that someone would be passing a forwardref there, but it will also work now.