### PR TITLE
Better error on incorrect protocol

### DIFF
--- a/magicgui/type_map.py
+++ b/magicgui/type_map.py
@@ -19,7 +19,7 @@ from magicgui.types import (
     WidgetRef,
     WidgetTuple,
 )
-from magicgui.widgets._protocols import WidgetProtocol
+from magicgui.widgets._protocols import WidgetProtocol, assert_protocol
 
 __all__: List[str] = ["register_type", "get_widget_class", "type_matcher"]
 
@@ -203,13 +203,9 @@ def get_widget_class(
     else:
         widget_class = widget_type
 
-    if not (
-        isinstance(widget_class, WidgetProtocol)
-        or _is_subclass(widget_class, widgets._bases.Widget)
-    ):
-        raise TypeError(
-            f"{widget_class!r} does not implement any known widget protocols"
-        )
+    if not _is_subclass(widget_class, widgets._bases.Widget):
+        assert_protocol(widget_class, WidgetProtocol)
+
     return widget_class, _options
 
 

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -221,8 +221,7 @@ class Widget:
         if not isinstance(_prot, str):
             _prot = _prot.__name__
         prot = getattr(_protocols, _prot.replace("_protocols.", ""))
-        if not isinstance(widget_type, prot):
-            raise TypeError(f"{widget_type!r} does not implement the proper protocol")
+        _protocols.assert_protocol(widget_type, prot)
         self.__magicgui_app__ = use_app()
         assert self.__magicgui_app__.native
         self._widget = widget_type(**backend_kwargs)

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -34,7 +34,7 @@ def _raise_protocol_error(widget_class: Type, protocol: Type):
     }
     message = (
         f"{widget_class!r} does not implement {protocol.__name__!r}.\n"
-        f"Missing members: {missing!r}"
+        f"Missing methods: {missing!r}"
     )
     raise TypeError(message)
 

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -9,7 +9,7 @@ For an example backend implementation, see ``magicgui.backends._qtpy.widgets``
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Tuple, Type
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -19,9 +19,32 @@ if TYPE_CHECKING:
     from magicgui.widgets._bases import Widget
 
 
+def assert_protocol(widget_class: Type, protocol: Type):
+    """Ensure that widget_class implements protocol, or raise helpful error."""
+    if not isinstance(widget_class, protocol):
+        _raise_protocol_error(widget_class, protocol)
+
+
+def _raise_protocol_error(widget_class: Type, protocol: Type):
+    """Raise a more helpful error when required protocol members are missing."""
+    missing = {
+        i
+        for i in set(dir(protocol)) - set(dir(widget_class))
+        if not i.startswith(("__", "_is_protocol", "_is_runtime", "_abc_impl"))
+    }
+    message = (
+        f"{widget_class!r} does not implement {protocol.__name__!r}.\n"
+        f"Missing members: {missing!r}"
+    )
+    raise TypeError(message)
+
+
 @runtime_checkable
 class WidgetProtocol(Protocol):
     """Base Widget Protocol: specifies methods that all widgets must provide."""
+
+    def __init__(self, **kwargs):
+        pass
 
     @abstractmethod
     def _mgui_show_widget(self) -> None:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -68,7 +68,8 @@ def test_custom_widget_fails():
     """Test that create_widget works with arbitrary backend implementations."""
     with pytest.raises(TypeError) as err:
         widgets.create_widget(1, widget_type=MyBadWidget)  # type: ignore
-    assert "does not implement any known widget protocols" in str(err)
+    assert "does not implement 'WidgetProtocol'" in str(err)
+    assert "Missing members: {'_mgui_show_widget'}" in str(err)
 
 
 def test_extra_kwargs_warn():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -69,7 +69,7 @@ def test_custom_widget_fails():
     with pytest.raises(TypeError) as err:
         widgets.create_widget(1, widget_type=MyBadWidget)  # type: ignore
     assert "does not implement 'WidgetProtocol'" in str(err)
-    assert "Missing members: {'_mgui_show_widget'}" in str(err)
+    assert "Missing methods: {'_mgui_show_widget'}" in str(err)
 
 
 def test_extra_kwargs_warn():


### PR DESCRIPTION
small PR to give a more helpful error message when a widget implementation does not match a given protocol (showing what methods still need to be implemented)