### PR TITLE
hotfix for signature inspection exception

### DIFF
--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -48,7 +48,11 @@ def merge_super_sigs(cls, exclude=("widget_type", "kwargs", "args", "kwds", "ext
     params = {}
     param_docs = []
     for sup in reversed(inspect.getmro(cls)):
-        sig = inspect.signature(getattr(sup, "__init__"))
+        try:
+            sig = inspect.signature(getattr(sup, "__init__"))
+        # in some environments `object` or `abc.ABC` will raise ValueError here
+        except ValueError:
+            continue
         for name, param in sig.parameters.items():
             if name in exclude:
                 continue


### PR DESCRIPTION
Discovered an issue here in the bundled napari app that I actually haven't seen in a non-bundled environment.  Not 100% sure why it's happening, but this fixes it.  Will release 0.2.2 so we can include in the napari bundle