### PR TITLE
Convert maximum/minimum kwargs to max/min and warn

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+ignore:
+  - magicgui/_version.py
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%  # coverage can drop by up to 0.5% while still posting success
+    patch:
+      default:
+        target: auto
+        threshold: 4%  # coverage can drop by up to 0.5% while still posting success
+comment:
+  require_changes: true  # if true: only post the PR comment if coverage changes

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -487,6 +487,18 @@ class RangedWidget(ValueWidget):
     _widget: _protocols.RangedWidgetProtocol
 
     def __init__(self, min: float = 0, max: float = 100, step: float = 1, **kwargs):
+        for key in ("maximum", "minimum"):
+            if key in kwargs:
+                warnings.warn(
+                    f"The {key!r} keyword arguments has been changed to {key[:3]!r}. "
+                    "In the future this will raise an exception\n",
+                    FutureWarning,
+                )
+                if key == "maximum":
+                    max = kwargs.pop(key)
+                else:
+                    min = kwargs.pop(key)
+
         super().__init__(**kwargs)
 
         self.min = min

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -194,6 +194,19 @@ class LogSlider(TransformedRangedWidget):
     def __init__(
         self, min: float = 1, max: float = 100, base: float = math.e, **kwargs
     ):
+        for key in ("maximum", "minimum"):
+            if key in kwargs:
+                import warnings
+
+                warnings.warn(
+                    f"The {key!r} keyword arguments has been changed to {key[:3]!r}. "
+                    "In the future this will raise an exception\n",
+                    FutureWarning,
+                )
+                if key == "maximum":
+                    max = kwargs.pop(key)
+                else:
+                    min = kwargs.pop(key)
         self._base = base
         app = use_app()
         assert app.native


### PR DESCRIPTION
One deprecation warning slipped through after #60 ... for those using `maximum` and `minimum` kwargs on their widgets, this will catch those kwargs and turn them to max/min and show a warning