### PR TITLE
Clarify choices callable deprecation warning

### DIFF
--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -751,12 +751,13 @@ class CategoricalWidget(ValueWidget):
                 n_params = len(inspect.signature(choices).parameters)
                 if n_params > 1:
                     warnings.warn(
-                        "\n\nAs of magicgui 0.2.0, a `choices` callable may accept only"
-                        " a single positional\nargument (an instance of "
-                        "`magicgui.widgets.CategoricalWidget`), and must return\nan "
-                        f"iterable (the choices to show). Function {choices.__name__!r}"
-                        f" accepts {n_params} arguments.\n"
-                        "In the future, this will raise an exception.\n",
+                        "\n\nAs of magicgui 0.2.0, when providing a callable to "
+                        "`choices`, the\ncallable may accept only a single positional "
+                        "argument (which will\nbe an instance of "
+                        "`magicgui.widgets._bases.CategoricalWidget`),\nand must "
+                        "return an iterable (the choices to show).\nFunction "
+                        f"'{choices.__module__}.{choices.__name__}' accepts {n_params} "
+                        "arguments.\nIn the future, this will raise an exception.\n",
                         FutureWarning,
                     )
                     # pre 0.2.0 API


### PR DESCRIPTION
The deprecation warning provided when a widget receives a `choices` option that is a callable using the pre 0.2.0 API is confusing.  The "main" user of providing a function as widget choices is probably napari's [`napari.utils._magicgui.get_layers`](https://github.com/napari/napari/blob/master/napari/utils/_magicgui.py#L80) function, which is registered with `magicgui.register_type` [right here](https://github.com/napari/napari/blob/a0b38907487d8bd32d2a7300bcbbecfcd5b00b40/napari/utils/_magicgui.py#L39).  As such, anyone using napari <0.4.3 with magicgui >= 0.2.0 will get a warning that is not their fault (see #81):

```
As of magicgui 0.2.0, a `choices` callable may accept only a single positional
argument (an instance of `magicgui.widgets.CategoricalWidget`), and must return
an iterable (the choices to show). Function 'get_layers' accepts 2 arguments.
In the future, this will raise an exception.
```

This PR catches that outdated earlier (when actually registering the type), provides only a `DeprecationWarning` that most users won't see

```
DEVELOPER NOTICE: As of magicgui 0.2.0, when providing a callable to `choices`, the
callable may accept only a single positional argument (which will be an instance of
`magicgui.widgets._bases.CategoricalWidget`), and must return an iterable (the choices
to show).  Function 'napari.utils._magicgui.get_viewers' accepts 2 arguments.
In the future, this will raise an exception.
```

and then patches the function to match the new API.