### PR TITLE
Add more examples (chaining, self-reference, and choices)

### DIFF
--- a/examples/chaining.py
+++ b/examples/chaining.py
@@ -1,0 +1,46 @@
+from magicgui import magicgui, widgets
+
+
+@magicgui(auto_call=True)
+def func_a(x: int = 64, y: int = 64):
+    print("calling func_a")
+    return x + y
+
+
+@magicgui(auto_call=True, input={"visible": False, "label": " ", "max": 100000})
+def func_b(input: int, mult=1.0):
+    print("calling func_b")
+    result = input * mult
+    # since these function defs live in globals(), you can update them directly
+    func_c.input.value = result
+    return result
+
+
+# alternatively, you can the `widget.called` signal to connect a callback function
+# where the result of the function being called is at `event.value`
+def _on_func_a(event):
+    func_b.input.value = event.value
+
+
+func_a.called.connect(_on_func_a)
+
+
+@magicgui(
+    auto_call=True,
+    input={"visible": False, "max": 100000},
+    result_widget=True,
+    labels=False,
+)
+def func_c(input: int, format: str = "({} + {}) * {} is {}") -> str:
+    print("calling func_c\n")
+    return format.format(func_a.x.value, func_a.y.value, func_b.mult.value, input)
+
+
+container = widgets.Container(
+    widgets=[func_a, func_b, func_c], layout="vertical", labels=False
+)
+container.native.setMinimumWidth(500)
+func_a()
+container.show(run=True)
+
+# notice which functions get called when you change each widget.

--- a/examples/choices.py
+++ b/examples/choices.py
@@ -1,0 +1,44 @@
+"""Choices for dropdowns can be provided in a few different ways."""
+from enum import Enum
+
+from magicgui import magicgui, widgets
+
+
+class Medium(Enum):
+    """Enum for various media and their refractive indices."""
+
+    Oil = 1.515
+    Water = 1.333
+    Air = 1.0003
+
+
+@magicgui(ri={"choices": ["Oil", "Water", "Air"]}, auto_call=True)
+def as_list(ri="Water"):
+    print("refractive index is", Medium[ri].value)
+
+
+@magicgui(auto_call=True)
+def as_enum(ri: Medium = Medium.Water):
+    print("refractive index is", ri.value)
+
+
+@magicgui(
+    ri={"choices": [("Oil", 1.515), ("Water", 1.33), ("Air", 1.0)]}, auto_call=True
+)
+def as_2tuple(ri=1.33):
+    print("refractive index is", ri)
+
+
+def get_choices(gui):
+    return [("Oil", 1.515), ("Water", 1.33), ("Air", 1.0)]
+
+
+@magicgui(ri={"choices": get_choices}, auto_call=True)
+def as_function(ri: float):
+    print("refractive index is", ri)
+
+
+container = widgets.Container(
+    widgets=[as_list, as_enum, as_2tuple, as_function], layout="vertical"
+)
+container.show(run=True)

--- a/examples/self_reference.py
+++ b/examples/self_reference.py
@@ -1,0 +1,12 @@
+from enum import auto
+
+from magicgui import magicgui
+
+
+@magicgui(auto_call=True, width={"max": 800, "min": 100}, x={"widget_type": "Slider"})
+def function(width=400, x: int = 50):
+    # the widget can reference itself, and use the widget API
+    function.x.width = width
+
+
+function.show(run=True)


### PR DESCRIPTION
Just adding a few more examples to the repo:

chaining shows two different ways to chain the output of one function into the input of another function, and autocall (only what is necessary) upon change.  (cc @haesleinhuepf) 

self-reference shows that you can update the parameters of the widget itself from within the decorated function (thanks for the inspiration on that one @haesleinhuepf! :))

choices shows all of the valid ways to provide a dropdown.  (cc @haesleinhuepf)