### PR TITLE
add call count to function gui

### DIFF
--- a/magicgui/function_gui.py
+++ b/magicgui/function_gui.py
@@ -96,6 +96,7 @@ class FunctionGui(Container):
         self._result_name = ""
         self._bound: Dict[str, Any] = {}
         self.bind(bind)
+        self._call_count: int = 0
 
         self._call_button: Optional[PushButton] = None
         if call_button:
@@ -117,6 +118,15 @@ class FunctionGui(Container):
 
         if show:
             self.show()
+
+    @property
+    def call_count(self) -> int:
+        """Return the number of times the function has been called."""
+        return self._call_count
+
+    def reset_call_count(self) -> None:
+        """Reset the call count to 0."""
+        self._call_count = 0
 
     def bind(self, kwargs: dict):
         """Bind key/value pairs to the function signature.
@@ -202,6 +212,7 @@ class FunctionGui(Container):
         bound.apply_defaults()
 
         value = self._function(*bound.args, **bound.kwargs)
+        self._call_count += 1
         if self._result_widget is not None:
             with self._result_widget.changed.blocker():
                 self._result_widget.value = value

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -463,3 +463,18 @@ def test_function_binding():
     assert b.method(sigma=4) == ("b", 4)
     assert a.method() == ("a", 2)
     assert b.method() == ("b", 5)
+
+
+def test_call_count():
+    """Test that a function gui remembers how many times it's been called."""
+
+    @magicgui
+    def func():
+        pass
+
+    assert func.call_count == 0
+    func()
+    func()
+    assert func.call_count == 2
+    func.reset_call_count()
+    assert func.call_count == 0


### PR DESCRIPTION
Add a call-count to FunctionGui.  @haesleinhuepf  could use this in `napari_pyclesperanto_assistant` [here](https://github.com/clEsperanto/napari_pyclesperanto_assistant/blob/851bb19b5190cc87477972f1fdb867f0f09ac066/napari_pyclesperanto_assistant/_gui/_LayerDialog.py#L25)