### PR TITLE
Fix ComboBox with unhashable choice data

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,10 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.5%  # coverage can drop by up to 0.5% while still posting success
+        threshold: 0.5% # coverage can drop by up to 0.5% while still posting success
     patch:
       default:
         target: auto
-        threshold: 4%  # coverage can drop by up to 0.5% while still posting success
+        threshold: 15% # coverage can drop by up to 15% while still posting success
 comment:
-  require_changes: true  # if true: only post the PR comment if coverage changes
+  require_changes: true # if true: only post the PR comment if coverage changes

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -212,3 +212,5 @@ def test_unhashable_choice_data():
     assert combo.choices == ("a", "b", "c")
     combo.choices = (("a", [1, 2, 3]), ("b", [1, 2, 5]))
     assert combo.choices == ([1, 2, 3], [1, 2, 5])
+    combo.choices = ("x", "y", "z")
+    assert combo.choices == ("x", "y", "z")

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -202,3 +202,13 @@ def test_widget_resolves_forward_ref():
         pass
 
     assert widget.x.annotation is MyInt
+
+
+def test_unhashable_choice_data():
+    """Test that providing unhashable choice data is ok."""
+    combo = widgets.ComboBox()
+    assert not combo.choices
+    combo.choices = ("a", "b", "c")
+    assert combo.choices == ("a", "b", "c")
+    combo.choices = (("a", [1, 2, 3]), ("b", [1, 2, 5]))
+    assert combo.choices == ([1, 2, 3], [1, 2, 5])


### PR DESCRIPTION
This allows the "data" for one of the choices in a categorical widget to be unhashable.
(for instance `combo.choices = (('a', [1,2,3]), ('b', [3,4,5))`)

This is necessary to implement the napari feature requested by @sofroniewn [here](https://github.com/napari/napari/pull/2079#pullrequestreview-562276660)