### PR TITLE
Extend combobox api with set_choice, get_choice, del_choice

### DIFF
--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -736,6 +736,30 @@ class CategoricalWidget(ValueWidget):
         self.choices = self._default_choices
 
     @property
+    def current_choice(self) -> str:
+        """Return the text of the currently selected choice."""
+        return self._widget._mgui_get_current_choice()
+
+    def __len__(self) -> int:
+        """Return the number of choices."""
+        return self._widget._mgui_get_count()
+
+    def get_choice(self, choice_name: str):
+        """Get data for the provided ``choice_name``."""
+        self._widget._mgui_get_choice(choice_name)
+
+    def set_choice(self, choice_name: str, data: Any = None):
+        """Set data for the provided ``choice_name``."""
+        data = data if data is not None else choice_name
+        self._widget._mgui_set_choice(choice_name, data)
+        if choice_name == self.current_choice:
+            self.changed(value=self.value)
+
+    def del_choice(self, choice_name: str, data: Any = None):
+        """Delete the provided ``choice_name`` and associated data."""
+        data = data if data is not None else choice_name
+
+    @property
     def choices(self):
         """Available value choices for this widget."""
         return tuple(i[1] for i in self._widget._mgui_get_choices())

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -177,6 +177,31 @@ class SupportsChoices(Protocol):
         """Set available choices."""
         raise NotImplementedError()
 
+    @abstractmethod
+    def _mgui_get_current_choice(self) -> str:
+        """Return the text of the currently selected choice."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _mgui_get_choice(self, choice_name: str) -> Any:
+        """Get data for a single choice."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _mgui_set_choice(self, choice_name: str, data: Any) -> None:
+        """Set data for choice_name, or add a new item if choice_name doesn't exist."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _mgui_del_choice(self, choice_name: str) -> None:
+        """Delete the provided ``choice_name`` and associated data."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _mgui_get_count(self) -> int:
+        """Return number of choices."""
+        raise NotImplementedError
+
 
 @runtime_checkable
 class CategoricalWidgetProtocol(ValueWidgetProtocol, SupportsChoices, Protocol):


### PR DESCRIPTION
This PR will help to fix an issue in napari where the data for a single choice become stale, but `refresh_choices` is not necessarily desirable, as it will update all choices in a CategoricalWidget.
It adds a few methods to get/set/delete the data for a single choice.

I'm considering, in the near future, making the categorical widget derive from `MutableMapping` (so it would behave like a dict where the keys are the strings in the combobox, and the values are the data associated with each).  so I'm not terrible concerned about the API yet.  This solves the immediate issue at hand