### PR TITLE
better bound values

### DIFF
--- a/magicgui/type_map.py
+++ b/magicgui/type_map.py
@@ -265,10 +265,12 @@ def register_type(
     """
     type_ = _evaluate_forwardref(type_)
 
-    if not (return_callback or options.get("choices") or widget_type):
+    if not (
+        return_callback or options.get("bind") or options.get("choices") or widget_type
+    ):
         raise ValueError(
-            "At least one of `widget_type`, `choices`, or "
-            "`return_callback` must be provided."
+            "At least one of `widget_type`, `return_callback`, `bind` or `choices` "
+            "must be provided."
         )
 
     if return_callback is not None:
@@ -295,6 +297,11 @@ def register_type(
                 '"widget_type" must be either a string, Widget, or WidgetProtocol'
             )
         _TYPE_DEFS[type_] = (widget_type, _options)
+    elif "bind" in _options:
+        # TODO: make a dedicated hidden widget?
+        # if we're binding a value to this parameter, it doesn't matter what type
+        # of ValueWidget is used... it usually won't be shown
+        _TYPE_DEFS[type_] = (widgets.Label, _options)
 
     return None
 

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -406,10 +406,14 @@ class ValueWidget(Widget):
     _widget: _protocols.ValueWidgetProtocol
     changed: EventEmitter
 
-    def __init__(self, value: Any = None, **kwargs):
+    def __init__(self, value: Any = None, bind=None, **kwargs):
+        self._bound_value: Any = bind
+        self._call_bound: bool = True
         super().__init__(**kwargs)
         if value is not None:
             self.value = value
+        if self._bound_value is not None and "visible" not in kwargs:
+            self.hide()
 
     def _post_init(self):
         super()._post_init()
@@ -418,10 +422,31 @@ class ValueWidget(Widget):
             lambda *x: self.changed(value=x[0] if x else None)
         )
 
+    def get_value(self):
+        """Callable version of `self.value`.
+
+        The main API is to use `self.value`, however, this is here in order to provide
+        an escape hatch if trying to access the widget's value inside of a callback
+        bound to self._bound_value.
+        """
+        return self._widget._mgui_get_value()
+
     @property
     def value(self):
         """Return current value of the widget.  This may be interpreted by backends."""
-        return self._widget._mgui_get_value()
+        if self._bound_value is not None:
+            if callable(self._bound_value) and self._call_bound:
+                try:
+                    return self._bound_value(self)
+                except RecursionError as e:
+                    raise RuntimeError(
+                        "RecursionError in callback bound to "
+                        f"<{self.widget_type!r} name={self.name!r}>. If you need to "
+                        "access `widget.value` in your bound callback, use "
+                        "`widget.get_value()`"
+                    ) from e
+            return self._bound_value
+        return self.get_value()
 
     @value.setter
     def value(self, value):
@@ -436,6 +461,38 @@ class ValueWidget(Widget):
             )
         else:
             return f"<Uninitialized {self.widget_type}>"
+
+    def bind(self, value: Any, call: bool = True) -> None:
+        """Binds ``value`` to self.value.
+
+        If a value is bound to this widget, then whenever `widget.value` is accessed,
+        the value provided here will be returned.  ``value`` can be a callable, in which
+        case ``value(self)`` will be returned (i.e. your callback must accept a single
+        parameter, which is this widget instance.).
+
+        If you provide a callable and you *don't* want it to be called (but rather just
+        returned as a callable object, then use ``call=False`` when binding your value.
+
+        Note: if you need to access the "original" ``widget.value`` within your
+        callback, please use ``widget.get_value()`` instead of the ``widget.value``
+        property, in order to avoid a RuntimeError.
+
+        Parameters
+        ----------
+        value : Any
+            The value (or callback) to return when accessing this widget's value.
+        call : bool, optional
+            If ``value`` is a callable and ``call`` is ``True``, the callback will be
+            called as ``callback(self)`` when accessing ``self.value``.  If ``False``,
+            the callback will simply be returned as a callable object, by default,
+            ``True``.
+        """
+        self._call_bound = call
+        self._bound_value = value
+
+    def unbind(self) -> None:
+        """Unbinds any bound values. (see ``ValueWidget.bind``)."""
+        self._bound_value = None
 
 
 class ButtonWidget(ValueWidget):
@@ -709,7 +766,7 @@ class CategoricalWidget(ValueWidget):
     @property
     def value(self):
         """Return current value of the widget."""
-        return self._widget._mgui_get_value()
+        return ValueWidget.value.fget(self)  # type: ignore
 
     @value.setter
     def value(self, value):
@@ -717,7 +774,7 @@ class CategoricalWidget(ValueWidget):
             raise ValueError(
                 f"{value!r} is not a valid choice. must be in {self.choices}"
             )
-        return self._widget._mgui_set_value(value)
+        return ValueWidget.value.fset(self, value)  # type: ignore
 
     @property
     def options(self) -> dict:
@@ -928,7 +985,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
             if key < 0:
                 key += len(self)
         item = self._widget._mgui_get_index(key)
-        if not item:
+        if item is None:
             raise IndexError("Container index out of range")
         return getattr(item, "_inner_widget", item)
 
@@ -976,7 +1033,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
             widget.changed.connect(lambda x: self.changed(value=self))
         _widget = widget
 
-        if self.labels:
+        if self.labels and _widget.visible:
             from ._concrete import _LabeledWidget
 
             # no labels for button widgets (push buttons, checkboxes, have their own)

--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -394,6 +394,9 @@ class Widget:
         self._widget._mgui_set_min_width(value)
 
 
+UNBOUND = object()
+
+
 class ValueWidget(Widget):
     """Widget with a value, Wraps ValueWidgetProtocol.
 
@@ -401,18 +404,24 @@ class ValueWidget(Widget):
     ----------
     value : Any, optional
         The starting value for the widget, by default ``None``
+    bind : Any, optional
+        A value or callback to bind this widget, then whenever `widget.value` is
+        accessed, the value provided here will be returned.  ``value`` can be a
+        callable, in which case ``value(self)`` will be returned (i.e. your callback
+        must accept a single parameter, which is this widget instance.).
+
     """
 
     _widget: _protocols.ValueWidgetProtocol
     changed: EventEmitter
 
-    def __init__(self, value: Any = None, bind=None, **kwargs):
+    def __init__(self, value: Any = None, bind: Any = UNBOUND, **kwargs):
         self._bound_value: Any = bind
         self._call_bound: bool = True
         super().__init__(**kwargs)
         if value is not None:
             self.value = value
-        if self._bound_value is not None and "visible" not in kwargs:
+        if self._bound_value is not UNBOUND and "visible" not in kwargs:
             self.hide()
 
     def _post_init(self):
@@ -434,7 +443,7 @@ class ValueWidget(Widget):
     @property
     def value(self):
         """Return current value of the widget.  This may be interpreted by backends."""
-        if self._bound_value is not None:
+        if self._bound_value is not UNBOUND:
             if callable(self._bound_value) and self._call_bound:
                 try:
                     return self._bound_value(self)
@@ -492,7 +501,7 @@ class ValueWidget(Widget):
 
     def unbind(self) -> None:
         """Unbinds any bound values. (see ``ValueWidget.bind``)."""
-        self._bound_value = None
+        self._bound_value = UNBOUND
 
 
 class ButtonWidget(ValueWidget):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -217,17 +217,35 @@ def test_unhashable_choice_data():
 
 
 def test_bound_values():
+    """Test that we can bind a "permanent" value override to a parameter."""
+
     @magicgui(x={"bind": 10})
     def f(x: int = 5):
         return x
 
+    # bound values hide the widget by default
     assert not f.x.visible
     assert f() == 10
     f.x.unbind()
     assert f() == 5
 
 
+def test_bound_values_visible():
+    """Test that we force a bound widget to be visible."""
+
+    @magicgui(x={"bind": 10, "visible": True})
+    def f(x: int = 5):
+        return x
+
+    assert f.x.visible
+    assert f() == 10
+    f.x.unbind()
+    assert f() == 5
+
+
 def test_bound_callables():
+    """Test that we can use a callable as a bound value."""
+
     @magicgui(x={"bind": lambda x: 10})
     def f(x: int = 5):
         return x
@@ -238,6 +256,8 @@ def test_bound_callables():
 
 
 def test_bound_callable_without_calling():
+    """Test that we can use a callable as a bound value, but return it directly."""
+
     def callback():
         return "hi"
 
@@ -252,6 +272,11 @@ def test_bound_callable_without_calling():
 
 
 def test_bound_callable_catches_recursion():
+    """Test that accessing widget.value raises an informative error message.
+
+    (... rather than a recursion error)
+    """
+
     @magicgui(x={"bind": lambda x: x.value * 2})
     def f(x: int = 5):
         return x

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -230,6 +230,18 @@ def test_bound_values():
     assert f() == 5
 
 
+def test_binding_None():
+    """Test that we can bind a "permanent" value override to a parameter."""
+
+    @magicgui(x={"bind": None})
+    def f(x: int = 5):
+        return x
+
+    assert f() is None
+    f.x.unbind()
+    assert f() == 5
+
+
 def test_bound_values_visible():
     """Test that we force a bound widget to be visible."""
 


### PR DESCRIPTION
This PR provides much better support for "binding" a value to a given widget (effectively circumventing `widget.value` when `widget._bound_value` is not `None`).  The bound value can also be a callable (that accepts a single param), in which case accessing `widget.value` will really return `widget._bound_value(widget)`.

All told, this makes it trivial for other libraries (like napari) to bind a value or callback to a parameter with a particular annotation (e.g. `def function(viewer: napari.Viewer)`) ... letting that parameter be hidden from the widget, but still present when calling the function.

Bound parameters are hidden by default, but can be shown explicitly with `{'visible': True}`.

For examples of how this can be used, see [tests here](https://github.com/napari/magicgui/pull/95/files#diff-af3529af46c0c6d7c1c94af472ea2a6b21b19cc715c2c7207e53f1c8f7fc9bdaR219-R266).

*edit: this also provides a much more elegant mechanism to decorate class methods #56  ... and undoes most of that PR*