### PR TITLE
Fix reset_choices recursion

### DIFF
--- a/magicgui/widgets/_bases.py
+++ b/magicgui/widgets/_bases.py
@@ -1034,8 +1034,8 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
         state.
         """
         for widget in self:
-            if isinstance(widget, CategoricalWidget):
-                widget.reset_choices()
+            if hasattr(widget, "reset_choices"):
+                widget.reset_choices()  # type: ignore
 
     def refresh_choices(self, event=None):
         """Alias for reset_choices [DEPRECATED: use reset_choices]."""

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -218,7 +218,6 @@ def test_unhashable_choice_data():
 
 def test_reset_choice_recursion():
     """Test that reset_choices recursion works for multiple types of widgets."""
-
     x = 0
 
     def get_choices(widget):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -214,3 +214,26 @@ def test_unhashable_choice_data():
     assert combo.choices == ([1, 2, 3], [1, 2, 5])
     combo.choices = ("x", "y", "z")
     assert combo.choices == ("x", "y", "z")
+
+
+def test_reset_choice_recursion():
+    """Test that reset_choices recursion works for multiple types of widgets."""
+
+    x = 0
+
+    def get_choices(widget):
+        nonlocal x
+        x += 1
+        return list(range(x))
+
+    @magicgui(c={"choices": get_choices})
+    def f(c):
+        pass
+
+    assert f.c.choices == (0,)
+
+    container = widgets.Container(widgets=[f])
+    container.reset_choices()
+    assert f.c.choices == (0, 1)
+    container.reset_choices()
+    assert f.c.choices == (0, 1, 2)


### PR DESCRIPTION
This fixes a bug in reset_choices recursion, when a FunctionWidget is nested inside of a Container