### PR TITLE
Fix tooltips for multiple params names on one line

### DIFF
--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -27,13 +27,24 @@ def _inject_tooltips_from_docstrings(
 
     if not docstring:
         return
-    for param in parse(docstring).params:
+
+    doc_params = {p.arg_name: p.description for p in parse(docstring).params}
+
+    # deal with the (numpydocs) case when there are multiple parameters separated
+    # by a comma
+    for k, v in list(doc_params.items()):
+        if "," in k:
+            for split_key in k.split(","):
+                doc_params[split_key.strip()] = v
+            del doc_params[k]
+
+    for name, description in doc_params.items():
         # this is to catch potentially bad arg_name parsing in docstring_parser
         # if using napoleon style google docstringss
-        argname = param.arg_name.split(" ", maxsplit=1)[0]
+        argname = name.split(" ", maxsplit=1)[0]
         if argname not in param_options:
             param_options[argname] = {}
-        desc = param.description.replace("`", "") if param.description else ""
+        desc = description.replace("`", "") if description else ""
         # use setdefault so as not to override an explicitly provided tooltip
         param_options[argname].setdefault("tooltip", desc)
 

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -524,6 +524,25 @@ the entirety of the docstring just like that"""
     assert not func.z.tooltip
 
 
+def test_duplicated_and_missing_params_from_numpydoc():
+    """Test that numpydocs docstrings can be used for tooltips."""
+
+    @magicgui
+    def func(x, y, z=None):
+        """Do a little thing.
+
+        Parameters
+        ----------
+        x, y : int
+            Integers for you to use
+        """
+        pass
+
+    assert func.x.tooltip == "Integers for you to use"
+    assert func.y.tooltip == "Integers for you to use"
+    assert not func.z.tooltip
+
+
 def test_tooltips_from_google_doc():
     """Test that google docstrings can be used for tooltips."""
 


### PR DESCRIPTION
another small bug fix when parsing tooltips from docs that have two parameters on one line, like:

```python
"""
        Parameters
        ----------
        x, y : int
            Integers for you to use
"""
```