### PR TITLE
Remove deprecated "result" param to `magicgui`

### DIFF
--- a/examples/OLD_snells_law.py
+++ b/examples/OLD_snells_law.py
@@ -24,8 +24,7 @@ class Medium(Enum):
     Air = 1.0003
 
 
-# result is deprecated ... use result_widget=True
-@magicgui(call_button="calculate", result={"disabled": True, "fixedWidth": 100})
+@magicgui(call_button="calculate", result_widget=True)
 def snells_law(aoi=30.0, n1=Medium.Glass, n2=Medium.Water, degrees=True):
     """Calculate the angle of refraction given two media and an AOI."""
     if degrees:

--- a/magicgui/_magicgui.py
+++ b/magicgui/_magicgui.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Optional, Union, overload
-from warnings import warn
 
 from typing_extensions import Literal
 
@@ -144,15 +143,6 @@ def magicgui(
     >>> my_function.a.value == 1  # True
     >>> my_function.b.value = 'world'
     """
-    if "result" in param_options:
-        warn(
-            "\n\nThe 'result' option is deprecated and will be removed in the future."
-            "Please use `result_widget=True` instead.\n",
-            FutureWarning,
-        )
-
-        param_options.pop("result")
-        result_widget = True
 
     def inner_func(func: Callable) -> FunctionGui:
         from magicgui.widgets import FunctionGui, MainFunctionGui


### PR DESCRIPTION
result has been changed to `result_widget`.  This removes the deprecation warning