### PR TITLE
Make vertical layout the default

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -501,7 +501,7 @@ class DateTimeEdit(QBaseValueWidget):
     def _mgui_get_value(self):
         try:
             return self._qwidget.dateTime().toPython()
-        except TypeError:
+        except (TypeError, AttributeError):
             return self._qwidget.dateTime().toPyDateTime()
 
 
@@ -512,7 +512,7 @@ class DateEdit(QBaseValueWidget):
     def _mgui_get_value(self):
         try:
             return self._qwidget.date().toPython()
-        except TypeError:
+        except (TypeError, AttributeError):
             return self._qwidget.date().toPyDate()
 
 
@@ -523,7 +523,7 @@ class TimeEdit(QBaseValueWidget):
     def _mgui_get_value(self):
         try:
             return self._qwidget.time().toPython()
-        except TypeError:
+        except (TypeError, AttributeError):
             return self._qwidget.time().toPyTime()
 
 

--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -75,7 +75,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
 
     def __init__(
         self,
-        layout: str = "horizontal",
+        layout: str = "vertical",
         widgets: Sequence[Widget] = (),
         labels=True,
         return_annotation: Any = None,
@@ -218,8 +218,9 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
                 measure(w.label) for w in self if not isinstance(w, ButtonWidget)
             )
             for w in self:
-                if hasattr(w, "label_width"):
-                    w.label_width = widest_label  # type: ignore
+                labeled_widget = w._labeled_widget()
+                if labeled_widget:
+                    labeled_widget.label_width = widest_label
 
     @property
     def margins(self) -> Tuple[int, int, int, int]:

--- a/magicgui/widgets/_bases/widget.py
+++ b/magicgui/widgets/_bases/widget.py
@@ -45,7 +45,7 @@ class Widget:
 
     _widget: _protocols.WidgetProtocol
     # if this widget becomes owned by a labeled widget
-    _labeled_widget: Optional["ReferenceType[_LabeledWidget]"] = None
+    _labeled_widget_ref: Optional["ReferenceType[_LabeledWidget]"] = None
 
     def __init__(
         self,
@@ -249,14 +249,18 @@ class Widget:
         """Set the tooltip for this widget."""
         return self._widget._mgui_set_tooltip(value)
 
+    def _labeled_widget(self) -> Optional[_LabeledWidget]:
+        """Return _LabeledWidget container, if applicable."""
+        return self._labeled_widget_ref() if self._labeled_widget_ref else None
+
     def show(self, run=False):
         """Show the widget."""
         self._widget._mgui_show_widget()
         self.visible = True
-        if self._labeled_widget is not None:
-            w = self._labeled_widget()
-            if w:
-                w.show()
+
+        labeled_widget = self._labeled_widget()
+        if labeled_widget is not None:
+            labeled_widget.show()
         if run:
             self.__magicgui_app__.run()
         return self  # useful for generating repr in sphinx
@@ -274,10 +278,10 @@ class Widget:
         """Hide widget."""
         self._widget._mgui_hide_widget()
         self.visible = False
-        if self._labeled_widget is not None:
-            w = self._labeled_widget()
-            if w:
-                w.hide()
+
+        labeled_widget = self._labeled_widget()
+        if labeled_widget is not None:
+            labeled_widget.hide()
 
     def render(self) -> "np.ndarray":
         """Return an RGBA (MxNx4) numpy array bitmap of the rendered widget."""

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -510,10 +510,9 @@ class _LabeledWidget(Container):
         position: str = "left",
         **kwargs,
     ):
-        layout = "horizontal" if position in ("left", "right") else "vertical"
-        kwargs["backend_kwargs"] = {"layout": layout}
+        kwargs["layout"] = "horizontal" if position in ("left", "right") else "vertical"
         self._inner_widget = widget
-        widget._labeled_widget = ref(self)
+        widget._labeled_widget_ref = ref(self)
         self._label_widget = Label(value=label or widget.label, tooltip=widget.tooltip)
         super().__init__(**kwargs)
         self.parent_changed.disconnect()  # don't need _LabeledWidget to trigger stuff

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -100,7 +100,7 @@ class FunctionGui(Container, Generic[_R]):
         self,
         function: Callable[..., _R],
         call_button: Union[bool, str] = False,
-        layout: str = "horizontal",
+        layout: str = "vertical",
         labels: bool = True,
         tooltips: bool = True,
         app: AppRef = None,

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -174,9 +174,9 @@ def test_container_widget():
     with pytest.raises(NotImplementedError):
         container[0] = "something"
 
-    assert container.layout == "horizontal"
+    assert container.layout == "vertical"
     with pytest.raises(NotImplementedError):
-        container.layout = "vertical"
+        container.layout = "horizontal"
 
     assert all(x in dir(container) for x in ["labela", "labelb"])
 


### PR DESCRIPTION
closes #121 by making `layout='vertical'` the default for magicgui and Containers