### PR TITLE
Make `_magicgui.pyi` stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,10 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [tokenize-rt==3.2.0]
+        args:
+          [
+            "--ignore-missing-imports",
+            "--scripts-are-modules",
+            "--no-warn-unused-ignores",
+          ]
         exclude: examples

--- a/magicgui/_magicgui.py
+++ b/magicgui/_magicgui.py
@@ -3,27 +3,15 @@ from __future__ import annotations
 import inspect
 from functools import partial
 from types import FunctionType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from warnings import warn
-
-from typing_extensions import Literal
 
 from magicgui.widgets import FunctionGui, MainFunctionGui
 
 if TYPE_CHECKING:
     from magicgui.application import AppRef
 
-_T = TypeVar("_T")
-_R = TypeVar("_R")
+__all__ = ["magicgui", "magic_factory", "MagicFactory"]
 
 
 def _magicgui(function=None, factory=False, main_window=False, **kwargs):
@@ -50,69 +38,6 @@ def _magicgui(function=None, factory=False, main_window=False, **kwargs):
         return inner_func
     else:
         return inner_func(function)
-
-
-# Overloads for magicgui decorator.  See implementation below
-# TODO: figure out how to get these in a stub file.
-# My first attempts to put them in ``_magicgui.pyi`` broke my type hints in VSCode
-# fmt: off
-@overload
-def magicgui(  # noqa
-    function: Callable[..., _R],
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[False] = False,
-    app: AppRef = None,
-    **param_options: dict,
-) -> FunctionGui[_R]: ...
-@overload  # noqa: E302
-def magicgui(  # noqa
-    function: Literal[None] = None,
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[False] = False,
-    app: AppRef = None,
-    **param_options: dict,
-) -> Callable[[Callable[..., _R]], FunctionGui[_R]]: ...
-@overload  # noqa: E302
-def magicgui(  # noqa
-    function: Callable[..., _R],
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[True],
-    app: AppRef = None,
-    **param_options: dict,
-) -> MainFunctionGui[_R]: ...
-@overload  # noqa: E302
-def magicgui(  # noqa
-    function=None,
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[True],
-    app: AppRef = None,
-    **param_options: dict,
-) -> Callable[[Callable[..., _R]], MainFunctionGui[_R]]: ...
-# fmt: on
 
 
 def magicgui(
@@ -184,7 +109,7 @@ def magicgui(
     return _magicgui(**locals())
 
 
-class MagicFactory(partial, Generic[_T]):
+class MagicFactory(partial):
     """Factory function that returns a FunctionGui instance.
 
     While this can be used directly, (see example below) the preferred usage is
@@ -240,7 +165,7 @@ class MagicFactory(partial, Generic[_T]):
         ]
         return f"MagicFactory({', '.join(args)})"
 
-    def __call__(self, *args, **kwargs) -> _T:
+    def __call__(self, *args, **kwargs):
         """Call the wrapped _magicgui and return a FunctionGui."""
         if args:
             raise ValueError("MagicFactory instance only accept keyword arguments")
@@ -257,69 +182,6 @@ class MagicFactory(partial, Generic[_T]):
     def __name__(self) -> str:
         """Pass function name."""
         return getattr(self.keywords.get("function"), "__name__", "FunctionGui")
-
-
-# Overloads for magic_factory decorator.  See implementation below
-# TODO: figure out how to get these in a stub file.
-# My first attempts to put them in ``_magicgui.pyi`` broke my type hints in VSCode
-# fmt: off
-@overload  # noqa: E302
-def magic_factory(  # noqa
-    function: Callable[..., _R],
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[False] = False,
-    app: AppRef = None,
-    **param_options: dict,
-) -> MagicFactory[FunctionGui[_R]]: ...
-@overload  # noqa: E302
-def magic_factory(  # noqa
-    function: Literal[None] = None,
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[False] = False,
-    app: AppRef = None,
-    **param_options: dict,
-) -> Callable[[Callable[..., _R]], MagicFactory[FunctionGui[_R]]]: ...
-@overload  # noqa: E302
-def magic_factory(  # noqa
-    function: Callable[..., _R],
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[True],
-    app: AppRef = None,
-    **param_options: dict,
-) -> MagicFactory[MainFunctionGui[_R]]: ...
-@overload  # noqa: E302
-def magic_factory(  # noqa
-    function: Literal[None] = None,
-    *,
-    layout: str = "horizontal",
-    labels: bool = True,
-    tooltips: bool = True,
-    call_button: Union[bool, str] = False,
-    auto_call: bool = False,
-    result_widget: bool = False,
-    main_window: Literal[True],
-    app: AppRef = None,
-    **param_options: dict,
-) -> Callable[[Callable[..., _R]], MagicFactory[MainFunctionGui[_R]]]: ...
-# fmt: on
 
 
 def magic_factory(

--- a/magicgui/_magicgui.pyi
+++ b/magicgui/_magicgui.pyi
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union, overload
+
+from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from magicgui.application import AppRef
+    from magicgui.widgets import FunctionGui, MainFunctionGui
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+
+class MagicFactory(partial, Generic[_T]):
+    def __new__(cls, function, *args, magic_class=FunctionGui, **keywords):
+        MagicFactory
+    def __repr__(self) -> str: ...
+    def __call__(self, *args, **kwargs) -> _T: ...
+    def __getattr__(self, name: str) -> Any: ...
+    @property
+    def __name__(self) -> str: ...
+
+@overload
+def magicgui(  # noqa
+    function: Callable[..., _R],
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[False] = False,
+    app: AppRef = None,
+    **param_options: dict,
+) -> FunctionGui[_R]: ...
+@overload  # noqa: E302
+def magicgui(  # noqa
+    function: Literal[None] = None,
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[False] = False,
+    app: AppRef = None,
+    **param_options: dict,
+) -> Callable[[Callable[..., _R]], FunctionGui[_R]]: ...
+@overload  # noqa: E302
+def magicgui(  # noqa
+    function: Callable[..., _R],
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[True],
+    app: AppRef = None,
+    **param_options: dict,
+) -> MainFunctionGui[_R]: ...
+@overload  # noqa: E302
+def magicgui(  # noqa
+    function=None,
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[True],
+    app: AppRef = None,
+    **param_options: dict,
+) -> Callable[[Callable[..., _R]], MainFunctionGui[_R]]: ...
+@overload  # noqa: E302
+def magic_factory(  # noqa
+    function: Callable[..., _R],
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[False] = False,
+    app: AppRef = None,
+    **param_options: dict,
+) -> MagicFactory[FunctionGui[_R]]: ...
+@overload  # noqa: E302
+def magic_factory(  # noqa
+    function: Literal[None] = None,
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[False] = False,
+    app: AppRef = None,
+    **param_options: dict,
+) -> Callable[[Callable[..., _R]], MagicFactory[FunctionGui[_R]]]: ...
+@overload  # noqa: E302
+def magic_factory(  # noqa
+    function: Callable[..., _R],
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[True],
+    app: AppRef = None,
+    **param_options: dict,
+) -> MagicFactory[MainFunctionGui[_R]]: ...
+@overload  # noqa: E302
+def magic_factory(  # noqa
+    function: Literal[None] = None,
+    *,
+    layout: str = "horizontal",
+    labels: bool = True,
+    tooltips: bool = True,
+    call_button: Union[bool, str] = False,
+    auto_call: bool = False,
+    result_widget: bool = False,
+    main_window: Literal[True],
+    app: AppRef = None,
+    **param_options: dict,
+) -> Callable[[Callable[..., _R]], MagicFactory[MainFunctionGui[_R]]]: ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,12 +112,6 @@ show_column_numbers = True
 show_error_codes = True
 # pretty = True
 
-[mypy-magicgui._tests.*]
-ignore_errors = True
-
-[mypy-magicgui._qt._tests.*]
-ignore_errors = True
-
 [mypy-.examples/]
 ignore_errors = True
 


### PR DESCRIPTION
The type annotations in `_magicgui.py` got a little unsightly in #117.  This puts all of the overloads and other typing stuff into `_magicgui.pyi`.  Tests for typing annotations were added (in the `typesafety` folder) in #117 and are still passing here.