### PR TITLE
add attribute error to `magicgui.__getattr__`

### DIFF
--- a/magicgui/__init__.py
+++ b/magicgui/__init__.py
@@ -35,3 +35,4 @@ def __getattr__(name: str):
         )
 
         return FunctionGui
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Adds an attribute error to `magicgui.__getattr__` in the case of a missing name