### PR TITLE
Improve issues with widget visibility

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -338,11 +338,11 @@ class MainWindow(Container):
         self._main_menu = self._main_window.menuBar()
         self._menus: Dict[str, QtW.QMenu] = {}
 
-    def _mgui_show_widget(self):
-        self._main_window.show()
+    def _mgui_get_visible(self):
+        return self._main_window.isVisible()
 
-    def _mgui_hide_widget(self):
-        self._main_window.hide()
+    def _mgui_set_visible(self, value: bool):
+        self._main_window.setVisible(value)
 
     def _mgui_get_native_widget(self) -> QtW.QMainWindow:
         return self._main_window

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -31,11 +31,11 @@ class QBaseWidget(_protocols.WidgetProtocol):
         self._event_filter = EventFilter()
         self._qwidget.installEventFilter(self._event_filter)
 
-    def _mgui_show_widget(self):
-        self._qwidget.show()
+    def _mgui_get_visible(self):
+        return self._qwidget.isVisible()
 
-    def _mgui_hide_widget(self):
-        self._qwidget.hide()
+    def _mgui_set_visible(self, value: bool):
+        self._qwidget.setVisible(value)
 
     def _mgui_get_enabled(self) -> bool:
         return self._qwidget.isEnabled()

--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -193,7 +193,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
             widget.changed.connect(lambda x: self.changed(value=self))
         _widget = widget
 
-        if self.labels and _widget.visible:
+        if self.labels:
             from magicgui.widgets._concrete import _LabeledWidget
 
             # no labels for button widgets (push buttons, checkboxes, have their own)

--- a/magicgui/widgets/_bases/widget.py
+++ b/magicgui/widgets/_bases/widget.py
@@ -138,7 +138,7 @@ class Widget:
     @property
     def options(self) -> dict:
         """Return options currently being used in this widget."""
-        return {"enabled": self.enabled, "visible": self._visible}
+        return {"enabled": self.enabled, "visible": self.visible}
 
     @property
     def native(self):

--- a/magicgui/widgets/_bases/widget.py
+++ b/magicgui/widgets/_bases/widget.py
@@ -94,7 +94,8 @@ class Widget:
         self._post_init()
         self._visible: bool = False
         self._explicitly_hidden: bool = False
-        self.visible = visible
+        if visible is not None:
+            self.visible = visible
 
     @property
     def annotation(self):
@@ -255,10 +256,16 @@ class Widget:
 
     @property
     def visible(self) -> bool:
+        """Return whether widget is visible."""
         return self._widget._mgui_get_visible()
 
     @visible.setter
     def visible(self, value: bool):
+        """Set widget visibility.
+
+        ``widget.show()`` is an alias for ``widget.visible = True``
+        ``widget.hide()`` is an alias for ``widget.visible = False``
+        """
         if value is None:
             return
 
@@ -270,7 +277,15 @@ class Widget:
             labeled_widget.visible = value
 
     def show(self, run=False):
-        """Show the widget."""
+        """Show widget.
+
+        alias for ``widget.visible = True``
+
+        Parameters
+        ----------
+        run : bool, optional
+            Whether to start the application event loop, by default False
+        """
         self.visible = True
         if run:
             self.__magicgui_app__.run()
@@ -286,7 +301,10 @@ class Widget:
             self.__magicgui_app__.__exit__()
 
     def hide(self):
-        """Hide widget."""
+        """Hide widget.
+
+        alias for ``widget.visible = False``
+        """
         self.visible = False
 
     def render(self) -> "np.ndarray":

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -393,6 +393,7 @@ class FileEdit(Container):
         self.filter = filter
         kwargs["widgets"] = [self.line_edit, self.choose_btn]
         kwargs["labels"] = False
+        kwargs["layout"] = "horizontal"
         super().__init__(**kwargs)
         self.margins = (0, 0, 0, 0)
         self._show_file_dialog = use_app().get_obj("show_file_dialog")

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -531,8 +531,9 @@ class _LabeledWidget(Container):
         kwargs["layout"] = "horizontal" if position in ("left", "right") else "vertical"
         self._inner_widget = widget
         widget._labeled_widget_ref = ref(self)
+        _visible = False if widget._explicitly_hidden else None
         self._label_widget = Label(value=label or widget.label, tooltip=widget.tooltip)
-        super().__init__(**kwargs)
+        super().__init__(**kwargs, visible=_visible)
         self.parent_changed.disconnect()  # don't need _LabeledWidget to trigger stuff
         self.labels = False  # important to avoid infinite recursion during insert!
         self._inner_widget.label_changed.connect(self._on_label_change)

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -84,7 +84,7 @@ class FunctionGui(Container, Generic[_R]):
         Whether tooltips are shown when hovering over widgets. by default True
     app : magicgui.Application or str, optional
         A backend to use, by default ``None`` (use the default backend.)
-    show : bool, optional
+    visible : bool, optional
         Whether to immediately show the widget, by default False
     auto_call : bool, optional
         If True, changing any parameter in either the GUI or the widget attributes
@@ -115,13 +115,14 @@ class FunctionGui(Container, Generic[_R]):
         labels: bool = True,
         tooltips: bool = True,
         app: AppRef = None,
-        show: bool = False,
+        visible: bool = False,
         auto_call: bool = False,
         result_widget: bool = False,
         param_options: Optional[Dict[str, dict]] = None,
         name: str = None,
         **kwargs,
     ):
+        print("FG, visible", visible)
         if not callable(function):
             raise TypeError("'function' argument to FunctionGui must be callable.")
 
@@ -155,6 +156,7 @@ class FunctionGui(Container, Generic[_R]):
         super().__init__(
             layout=layout,
             labels=labels,
+            visible=visible,
             widgets=list(sig.widgets(app).values()),
             return_annotation=sig.return_annotation,
             name=name or self._callable_name,
@@ -187,9 +189,6 @@ class FunctionGui(Container, Generic[_R]):
         self._auto_call = auto_call
         if auto_call:
             self.changed.connect(lambda e: self.__call__())
-
-        if show:
-            self.show()
 
     @property
     def call_count(self) -> int:
@@ -277,7 +276,7 @@ class FunctionGui(Container, Generic[_R]):
 
     def __repr__(self) -> str:
         """Return string representation of instance."""
-        return f"<FunctionGui {self._callable_name}{self.__signature__}>"
+        return f"<{type(self).__name__} {self._callable_name}{self.__signature__}>"
 
     @property
     def result_name(self) -> str:
@@ -363,6 +362,7 @@ class MainFunctionGui(FunctionGui[_R], MainWindow):
     _widget: MainWindowProtocol
 
     def __init__(self, function: Callable, *args, **kwargs):
+        print(kwargs)
         super().__init__(function, *args, **kwargs)
         self.create_menu_item("Help", "Documentation", callback=self._show_docs)
         self._help_text_edit: Optional[TextEdit] = None

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -56,13 +56,13 @@ class WidgetProtocol(Protocol):
         pass
 
     @abstractmethod
-    def _mgui_show_widget(self) -> None:
-        """Show the widget."""
+    def _mgui_get_visible(self):
+        """Get widget visibility."""
         raise NotImplementedError()
 
     @abstractmethod
-    def _mgui_hide_widget(self) -> None:
-        """Hide the widget."""
+    def _mgui_set_visible(self, value: bool):
+        """Set widget visibility."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -262,6 +262,7 @@ def test_invisible_param():
         return "works"
 
     assert hasattr(func, "a")
+    func.show()
     assert not func.a.visible
     assert func.b.visible
     assert func.c.visible

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -38,6 +38,7 @@ def test_no_leave_tqdm():
             pass
         assert pbar1.progressbar.visible is True
 
+    f.show()
     f()
 
     @magicgui

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -116,9 +116,9 @@ def test_basic_widget_attributes():
     widget.enabled = False
     assert not widget.enabled
 
-    assert widget.visible
-    widget.visible = False
     assert not widget.visible
+    widget.show()
+    assert widget.visible
 
     assert widget.parent is None
     container.append(widget)
@@ -219,13 +219,13 @@ def test_labeled_widget_container():
     assert w1._labeled_widget
     lw = w1._labeled_widget()
     assert isinstance(lw, _LabeledWidget)
-    assert lw.visible
-    w1.hide()
-    assert not w1.visible
     assert not lw.visible
     w1.show()
     assert w1.visible
     assert lw.visible
+    w1.hide()
+    assert not w1.visible
+    assert not lw.visible
     w1.label = "another label"
     assert lw._label_widget.value == "another label"
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -40,7 +40,8 @@ def test_create_widget(kwargs, expect_type):
 class MyBadWidget:
     """INCOMPLETE widget implementation and will error."""
 
-    def _mgui_hide_widget(self): ... # noqa
+    def _mgui_get_visible(self): ... # noqa
+    def _mgui_set_visible(self): ... # noqa
     def _mgui_get_enabled(self): ... # noqa
     def _mgui_set_enabled(self, enabled): ... # noqa
     def _mgui_get_parent(self): ... # noqa
@@ -64,13 +65,13 @@ class MyBadWidget:
     def _mgui_set_value(self, value): ... # noqa
     def _mgui_bind_change_callback(self, callback): ... # noqa
     def _mgui_get_tooltip(self, value): ... # noqa
-    def _mgui_set_tooltip(self, value): ... # noqa
+    # def _mgui_set_tooltip(self, value): ... # noqa
 
 
 class MyValueWidget(MyBadWidget):
     """Complete protocol implementation... should work."""
 
-    def _mgui_show_widget(self): ... # noqa
+    def _mgui_set_tooltip(self, value): ... # noqa
 # fmt: on
 
 
@@ -88,7 +89,7 @@ def test_custom_widget_fails():
     with pytest.raises(TypeError) as err:
         widgets.create_widget(1, widget_type=MyBadWidget)  # type: ignore
     assert "does not implement 'WidgetProtocol'" in str(err)
-    assert "Missing methods: {'_mgui_show_widget'}" in str(err)
+    assert "Missing methods: {'_mgui_set_tooltip'}" in str(err)
 
 
 def test_extra_kwargs_warn():
@@ -128,7 +129,7 @@ def test_basic_widget_attributes():
     assert widget.label == "my name"
     widget.label = "A different label"
     assert widget.label == "A different label"
-    assert widget.width > 200
+    assert widget.width < 100
     widget.width = 150
     assert widget.width == 150
 
@@ -215,12 +216,12 @@ def test_labeled_widget_container():
 
     w1 = widgets.Label(value="hi", name="w1")
     w2 = widgets.Label(value="hi", name="w2")
-    _ = widgets.Container(widgets=[w1, w2], layout="vertical")
+    container = widgets.Container(widgets=[w1, w2], layout="vertical")
     assert w1._labeled_widget
     lw = w1._labeled_widget()
     assert isinstance(lw, _LabeledWidget)
     assert not lw.visible
-    w1.show()
+    container.show()
     assert w1.visible
     assert lw.visible
     w1.hide()
@@ -228,6 +229,24 @@ def test_labeled_widget_container():
     assert not lw.visible
     w1.label = "another label"
     assert lw._label_widget.value == "another label"
+
+
+def test_visible_in_container():
+    """Test that visibility depends on containers."""
+    w1 = widgets.Label(value="hi", name="w1")
+    w2 = widgets.Label(value="hi", name="w2")
+    w3 = widgets.Label(value="hi", name="w2", visible=False)
+    container = widgets.Container(widgets=[w2, w3])
+    assert not w1.visible
+    assert not w2.visible
+    assert not w3.visible
+    assert not container.visible
+    container.show()
+    assert container.visible
+    assert w2.visible
+    assert not w3.visible
+    w1.show()
+    assert w1.visible
 
 
 def test_delete_widget():
@@ -299,6 +318,7 @@ def test_bound_values_visible():
     def f(x: int = 5):
         return x
 
+    f.show()
     assert f.x.visible
     assert f() == 10
     f.x.unbind()
@@ -431,6 +451,10 @@ def test_main_function_gui():
         int
             Resulting integer
         """
+
+    assert not add.visible
+    add.show()
+    assert add.visible
 
     assert isinstance(add, widgets.MainFunctionGui)
     add._show_docs()


### PR DESCRIPTION
This PR fixes a few bugs around widget visibility, such as an initial disagreement between the `widget.visible` attribute and the actual visibility of the widget.
It also makes sure that widgets (and their labels) explicitly hidden with `widget.hide()` are not shown in containers, but can be reshown on demand.