### PR TITLE
Improve fallback behavior of tqdm iterator inside of *hidden* magicgui widget

### DIFF
--- a/examples/progress.py
+++ b/examples/progress.py
@@ -8,7 +8,7 @@ from magicgui.tqdm import trange
 
 # If use inside of a magicgui-decorated function
 # a progress bar widget will be added to the magicgui container
-@magicgui(call_button=True)
+@magicgui(call_button=True, layout="horizontal")
 def long_running(steps=10, delay=0.1):
     """Long running computation with range iterator."""
     # trange(steps) is a shortcut for `tqdm(range(steps))`

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -122,7 +122,6 @@ class FunctionGui(Container, Generic[_R]):
         name: str = None,
         **kwargs,
     ):
-        print("FG, visible", visible)
         if not callable(function):
             raise TypeError("'function' argument to FunctionGui must be callable.")
 
@@ -362,7 +361,6 @@ class MainFunctionGui(FunctionGui[_R], MainWindow):
     _widget: MainWindowProtocol
 
     def __init__(self, function: Callable, *args, **kwargs):
-        print(kwargs)
         super().__init__(function, *args, **kwargs)
         self.create_menu_item("Help", "Documentation", callback=self._show_docs)
         self._help_text_edit: Optional[TextEdit] = None

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -137,31 +137,15 @@ def test_trange_inside_of_magicgui():
     assert len(long_func._tqdm_pbars) == 1
 
 
-@magicgui
-def directly_decorated(steps=2):
-    for i in trange(4):
-        pass
-
-
-def test_trange_inside_of_global_magicgui():
-    """Test that trange can find the magicgui within which it is called."""
-    directly_decorated.show()
-    assert not directly_decorated._tqdm_pbars
-    directly_decorated()
-    assert len(directly_decorated._tqdm_pbars) == 1
-
-
 def _indirectly_decorated(steps=2):
     for i in trange(4):
         pass
 
 
-indirectly_decorated = magicgui(_indirectly_decorated)
-indirectly_decorated.show()
-
-
 def test_trange_inside_of_indirectly_decorated_magicgui():
     """Test that trange can find the magicgui within which it is called."""
+    indirectly_decorated = magicgui(_indirectly_decorated)
+    indirectly_decorated.show()
     assert not indirectly_decorated._tqdm_pbars
     indirectly_decorated()
     assert len(indirectly_decorated._tqdm_pbars) == 1

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -47,6 +47,7 @@ def test_no_leave_tqdm():
             pass
         assert pbar2.progressbar.visible is False
 
+    f2.show()
     f2()
 
 
@@ -60,7 +61,44 @@ def test_unbound_tqdm():
             # undefined range will render as a "busy" indicator
             assert pbar.progressbar.range == (0, 0)
 
+    f.show()
     f()
+
+
+def test_tqdm_std_err(capsys):
+    """Test that tqdm inside an invisible magicgui falls back to console behavior."""
+
+    # outside of a magicgui it falls back to tqdm_std behavior
+    with tqdm(range(10)) as t_obj:
+        iter(t_obj)
+    captured = capsys.readouterr()
+
+    assert "0%|" in str(captured.err)
+    assert "| 0/10" in str(captured.err)
+    assert not str(captured.out)
+
+
+def test_tqdm_in_visible_mgui_std_err(capsys):
+    """Test that tqdm inside an mgui outputs to console only when mgui not visible."""
+
+    # inside of a of a magicgui it falls back to tqdm_std behavior
+    @magicgui
+    def f():
+        with tqdm(range(10)) as t_obj:
+            iter(t_obj)
+
+    f()
+    captured = capsys.readouterr()
+    assert "0%|" in str(captured.err)
+    assert "| 0/10" in str(captured.err)
+    assert not str(captured.out)
+
+    # showing the widget disables the output to console behavior
+    f.show()
+    f()
+    captured = capsys.readouterr()
+    assert not str(captured.err)
+    assert not str(captured.out)
 
 
 # Test various ways that tqdm might need to traverse the frame stack:
@@ -75,6 +113,7 @@ def test_tqdm_inside_of_magicgui():
             sleep(0.02)
 
     # before calling the function, we won't have any progress bars
+    long_func.show()
     assert not long_func._tqdm_pbars
     long_func()
     # after calling the it, we should now have a progress bars
@@ -92,6 +131,7 @@ def test_trange_inside_of_magicgui():
         for i in trange(4):
             pass
 
+    long_func.show()
     assert not long_func._tqdm_pbars
     long_func()
     assert len(long_func._tqdm_pbars) == 1
@@ -105,6 +145,7 @@ def directly_decorated(steps=2):
 
 def test_trange_inside_of_global_magicgui():
     """Test that trange can find the magicgui within which it is called."""
+    directly_decorated.show()
     assert not directly_decorated._tqdm_pbars
     directly_decorated()
     assert len(directly_decorated._tqdm_pbars) == 1
@@ -116,6 +157,7 @@ def _indirectly_decorated(steps=2):
 
 
 indirectly_decorated = magicgui(_indirectly_decorated)
+indirectly_decorated.show()
 
 
 def test_trange_inside_of_indirectly_decorated_magicgui():
@@ -134,6 +176,7 @@ def test_tqdm_nested():
             for x in trange(4):
                 pass
 
+    long_func.show()
     # before calling the function, we won't have any progress bars
     assert not long_func._tqdm_pbars
     long_func()
@@ -150,6 +193,7 @@ def test_tqdm_nested():
         for x in trange(4):
             pass
 
+    long_func2.show()
     # before calling the function, we won't have any progress bars
     assert not long_func2._tqdm_pbars
     long_func2()


### PR DESCRIPTION
This PR allows a `tqdm` iterator to fallback to the standard console behavior even when inside of an `@magicgui` decorated function, if the widget is not visible.