### PR TITLE
Add `magicgui.*` objectName to qt widgets

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -28,6 +28,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def __init__(self, qwidg: QtW.QWidget):
         self._qwidget = qwidg()
+        self._qwidget.setObjectName(f"magicgui.{qwidg.__name__}")
         self._event_filter = EventFilter()
         self._qwidget.installEventFilter(self._event_filter)
 


### PR DESCRIPTION
For debugging purposes, this adds a "magicgui.*" objectName to all QWidgets created by magicgui