### PR TITLE
Move return_annotation from container to FunctionGui

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -575,7 +575,8 @@ class Table(QBaseWidget, _protocols.TableWidgetProtocol):
 
     def __init__(self):
         super().__init__(QtW.QTableWidget)
-        self._qwidget.horizontalHeader().setSectionResizeMode(QtW.QHeaderView.Stretch)
+        header = self._qwidget.horizontalHeader()
+        header.setSectionResizeMode(QtW.QHeaderView.Stretch)
         # self._qwidget.horizontalHeader().setSectionsMovable(True)  # tricky!!
         self._qwidget.itemChanged.connect(self._update_item_data_with_text)
 

--- a/magicgui/signature.py
+++ b/magicgui/signature.py
@@ -73,6 +73,10 @@ def split_annotated_type(annotation: _AnnotatedAlias) -> Tuple[Any, WidgetOption
     return annotation.__args__[0], meta
 
 
+class _void:
+    """private sentinel."""
+
+
 class MagicParameter(inspect.Parameter):
     """A Parameter subclass that is closely linked to a magicgui.Widget object.
 
@@ -223,9 +227,27 @@ class MagicSignature(inspect.Signature):
 
         return Container(
             widgets=list(self.widgets(kwargs.get("app")).values()),
-            return_annotation=self.return_annotation,
             **kwargs,
         )
+
+    def replace(
+        self,
+        *,
+        parameters=_void,
+        return_annotation: Any = _void,
+    ) -> MagicSignature:
+        """Create a customized copy of the Signature.
+
+        Pass ``parameters`` and/or ``return_annotation`` arguments
+        to override them in the new copy.
+        """
+        if parameters is _void:
+            parameters = self.parameters.values()
+
+        if return_annotation is _void:
+            return_annotation = self.return_annotation
+
+        return type(self)(parameters, return_annotation=return_annotation)
 
 
 def magic_signature(

--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -5,7 +5,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ForwardRef,
     List,
     MutableSequence,
     Optional,
@@ -63,9 +62,6 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
         Whether each widget should be shown with a corresponding Label widget to the
         left, by default ``True``.  Note: the text for each widget defaults to
         ``widget.name``, but can be overriden by setting ``widget.label``.
-    return_annotation : type or str, optional
-        An optional return annotation to use when representing this container of
-        widgets as an :class:`inspect.Signature`, by default ``None``
     """
 
     changed: EventEmitter
@@ -77,37 +73,18 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
         layout: str = "vertical",
         widgets: Sequence[Widget] = (),
         labels=True,
-        return_annotation: Any = None,
         **kwargs,
     ):
         self._list: List[Widget] = []
-        self._return_annotation = None
         self._labels = labels
         self._layout = layout
         kwargs["backend_kwargs"] = {"layout": layout}
         super().__init__(**kwargs)
         self.changed = EventEmitter(source=self, type="changed")
-        self.return_annotation = return_annotation
         self.extend(widgets)
         self.parent_changed.connect(self.reset_choices)
         self._initialized = True
         self._unify_label_widths()
-
-    @property
-    def return_annotation(self):
-        """Return annotation to use when converting to :class:`inspect.Signature`.
-
-        ForwardRefs will be resolve when setting the annotation.
-        """
-        return self._return_annotation
-
-    @return_annotation.setter
-    def return_annotation(self, value):
-        if isinstance(value, (str, ForwardRef)):
-            from magicgui.type_map import _evaluate_forwardref
-
-            value = _evaluate_forwardref(value)
-        self._return_annotation = value
 
     def __getattr__(self, name: str):
         """Return attribute ``name``.  Will return a widget if present."""
@@ -269,7 +246,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
             elif seen_default:
                 params.sort(key=lambda x: x.default is not MagicParameter.empty)
                 break
-        return MagicSignature(params, return_annotation=self.return_annotation)
+        return MagicSignature(params)
 
     @classmethod
     def from_signature(cls, sig: inspect.Signature, **kwargs) -> Container:


### PR DESCRIPTION
It never really made sense for a Container Widget to have a return annotation. (it was only there for FunctionGui to use).  This moves it over to FunctionGui