### PR TITLE
fix function with no params and callbutton

### DIFF
--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -207,11 +207,11 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
     def _unify_label_widths(self, event=None):
         if not self._initialized:
             return
-        if self.layout == "vertical" and self.labels and len(self):
+
+        need_labels = [w for w in self if not isinstance(w, ButtonWidget)]
+        if self.layout == "vertical" and self.labels and need_labels:
             measure = use_app().get_obj("get_text_width")
-            widest_label = max(
-                measure(w.label) for w in self if not isinstance(w, ButtonWidget)
-            )
+            widest_label = max(measure(w.label) for w in need_labels)
             for w in self:
                 labeled_widget = w._labeled_widget()
                 if labeled_widget:

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -635,3 +635,13 @@ def test_local_magicgui_self_reference():
         return local_self_referencing_function
 
     assert isinstance(local_self_referencing_function(), widgets.FunctionGui)
+
+
+def test_empty_function():
+    """Test that a function with no params works."""
+
+    @magicgui(call_button=True)
+    def f():
+        ...
+
+    f.show()


### PR DESCRIPTION
This fixes a bug when creating a vertically oriented magicgui with `call_button=True`, when there are no parameters in the function

closes #146