### PR TITLE
allow label to be alias for text in button widgets

### DIFF
--- a/magicgui/widgets/_bases/button_widget.py
+++ b/magicgui/widgets/_bases/button_widget.py
@@ -19,6 +19,14 @@ class ButtonWidget(ValueWidget):
     changed: EventEmitter
 
     def __init__(self, text: Optional[str] = None, **kwargs):
+        if text and kwargs.get("label"):
+            from warnings import warn
+
+            warn(
+                "'text' and 'label' are synonymous for button widgets. To suppress this"
+                " warning, only provide one of the two kwargs."
+            )
+        text = text or kwargs.get("label")
         super().__init__(**kwargs)
         self.text = text or self.name
 

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -635,3 +635,21 @@ def test_local_magicgui_self_reference():
         return local_self_referencing_function
 
     assert isinstance(local_self_referencing_function(), widgets.FunctionGui)
+
+
+def test_boolean_label():
+    """Test that label can be used to set the text of a button widget."""
+
+    @magicgui(check={"label": "ABC"})
+    def test(check: bool, x=1):
+        pass
+
+    assert test.check.text == "ABC"
+
+    with pytest.warns(UserWarning) as record:
+
+        @magicgui(check={"text": "ABC", "label": "BCD"})
+        def test2(check: bool, x=1):
+            pass
+
+    assert "'text' and 'label' are synonymous for button widgets" in str(record[0])


### PR DESCRIPTION
closes #109 by allowing `label` to serve as an alias for `text` on button widgets.