### PR TITLE
Allow `magicgui.types.PathLike` annotation

### DIFF
--- a/magicgui/type_map.py
+++ b/magicgui/type_map.py
@@ -15,6 +15,7 @@ from typing_extensions import get_args, get_origin
 
 from magicgui import widgets
 from magicgui.types import (
+    PathLike,
     ReturnCallback,
     TypeMatcher,
     WidgetClass,
@@ -152,6 +153,14 @@ def sequence_of_paths(value, annotation) -> WidgetTuple | None:
     return None
 
 
+@type_matcher
+def pathlike(value, annotation) -> WidgetTuple | None:
+    """Determine if annotation is magicgui.types.PathLike."""
+    if annotation is PathLike:
+        return widgets.FileEdit, {}
+    return None
+
+
 def pick_widget_type(
     value: Any = None, annotation: type | None = None, options: WidgetOptions = {}
 ) -> WidgetTuple:
@@ -178,6 +187,13 @@ def pick_widget_type(
         if _widget_type:
             return _widget_type
 
+    if options:
+        raise ValueError(
+            "magicgui received parameter-specific options for an unrecognized type:\n"
+            f"value: {value}\n"
+            f"type: {annotation}\n"
+            f"options: {options}"
+        )
     return widgets.EmptyWidget, {"visible": False}
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -56,6 +56,9 @@ def test_forward_refs_return_annotation():
 
 
 def test_pathlike_annotation():
+    import pathlib
+    from typing import Union
+
     from magicgui import magicgui, types
 
     @magicgui(fn={"mode": "r"})
@@ -65,8 +68,9 @@ def test_pathlike_annotation():
     assert isinstance(widget.fn, widgets.FileEdit)
     assert widget.fn.mode is types.FileDialogMode.EXISTING_FILE
 
+    # an equivalent union also works
     @magicgui(fn={"mode": "rm"})
-    def widget2(fn: types.PathLike):
+    def widget2(fn: Union[bytes, pathlib.Path, str]):
         print(fn)
 
     assert isinstance(widget2.fn, widgets.FileEdit)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -53,3 +53,21 @@ def test_forward_refs_return_annotation():
     assert result == 1
     # the forward ref has been resolved
     assert return_annotation is MyInt
+
+
+def test_pathlike_annotation():
+    from magicgui import magicgui, types
+
+    @magicgui(fn={"mode": "r"})
+    def widget(fn: types.PathLike):
+        print(fn)
+
+    assert isinstance(widget.fn, widgets.FileEdit)
+    assert widget.fn.mode is types.FileDialogMode.EXISTING_FILE
+
+    @magicgui(fn={"mode": "rm"})
+    def widget2(fn: types.PathLike):
+        print(fn)
+
+    assert isinstance(widget2.fn, widgets.FileEdit)
+    assert widget2.fn.mode is types.FileDialogMode.EXISTING_FILES

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 import pytest
 
-from magicgui import magicgui, register_type, widgets
+from magicgui import magicgui, register_type, types, widgets
 
 
 def test_forward_refs():
@@ -58,8 +58,6 @@ def test_forward_refs_return_annotation():
 def test_pathlike_annotation():
     import pathlib
     from typing import Union
-
-    from magicgui import magicgui, types
 
     @magicgui(fn={"mode": "r"})
     def widget(fn: types.PathLike):


### PR DESCRIPTION
closes #144 by allowing a `types.PathLike` annotation to render a FileEdit widget.

@jni,  there's an interesting decision/distinction to make here:

Since `magicgui.types.PathLike` is just a type alias, and not a `NewType` ... what's really happening here is that magicgui is just checking whether the annotation is "somehow equivalent" to `typing.Union[pathlib.Path, str, bytes]`.  What's interesting is that we can either check for literal type alias object identity using "is" (`if annotation is PathLike`), _or_, because `Union` evaluates to true like an unordered set would, then we could use "==" (`if annotation == PathLike`) and get the same behavior if someone manually annotated something as `typing.Union[pathlib.Path, str, bytes]` (in any order).  Which do you think is best here?  (currently using `is`)

**edit**:  ooohhh, TIL that types and their aliases actually do some nice things with object identity and hashing:

```python
In [13]: from typing import Union
    ...:
    ...: x = Union[int, str]
    ...: y = Union[int, str]
    ...: z = Union[str, int]

# x and y point to the same object
In [14]: x is y
Out[14]: True

# but not z, which was swapped in order
In [15]: x is z
Out[15]: False

# however, all three have the same hash:
In [18]: a = {x, y, z}

In [19]: a
Out[19]: {typing.Union[int, str]}
```

that hashability means they can be used easily as keys in dicts, which will be much easier going forward, so I changed this PR over to "type equivalence" rather than "identity", and this will also work:

```python
@magicgui(fn={"mode": "rm"})
def widget(fn: Union[bytes, pathlib.Path, str]): ...
```