### PR TITLE
Fix napari return annotations

### DIFF
--- a/examples/napari_forward_refs.py
+++ b/examples/napari_forward_refs.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
 
 @magicgui(call_button="execute", background={"max": 200})
 def subtract_background(
-    layerA: "napari.layers.Image", background: int = 50
-) -> "napari.layers.Image":
-    """Add, subtracts, multiplies, or divides to image layers with equal shape."""
-    if layerA:
-        return layerA.data + background
+    data: "napari.types.ImageData", background: int = 50
+) -> "napari.types.ImageData":
+    """Subtract a contstant from the data."""
+    if data:
+        return data - background
 
 
 subtract_background.show(run=True)

--- a/examples/napari_image_arithmetic.py
+++ b/examples/napari_image_arithmetic.py
@@ -4,6 +4,7 @@ from enum import Enum
 import numpy
 from napari import Viewer, gui_qt
 from napari.layers import Image
+from napari.types import ImageData
 
 from magicgui import magicgui
 
@@ -29,9 +30,10 @@ with gui_qt():
     viewer.add_image(numpy.random.rand(20, 20), name="Layer 2")
 
     # use the magic decorator!  This takes a function, and generates a widget instance
-    # using the function signature.
+    # using the function signature. Note that we aren't returning a napari Image layer,
+    # but instead a numpy array which we want napari to interperate as Image data.
     @magicgui(call_button="execute")
-    def image_arithmetic(layerA: Image, operation: Operation, layerB: Image) -> Image:
+    def image_arithmetic(layerA: Image, operation: Operation, layerB: Image) -> ImageData:
         """Add, subtracts, multiplies, or divides to image layers with equal shape."""
         return operation.value(layerA.data, layerB.data)
 

--- a/examples/napari_image_arithmetic.py
+++ b/examples/napari_image_arithmetic.py
@@ -33,7 +33,9 @@ with gui_qt():
     # using the function signature. Note that we aren't returning a napari Image layer,
     # but instead a numpy array which we want napari to interperate as Image data.
     @magicgui(call_button="execute")
-    def image_arithmetic(layerA: Image, operation: Operation, layerB: Image) -> ImageData:
+    def image_arithmetic(
+        layerA: Image, operation: Operation, layerB: Image
+    ) -> ImageData:
         """Add, subtracts, multiplies, or divides to image layers with equal shape."""
         return operation.value(layerA.data, layerB.data)
 

--- a/examples/napari_param_sweep.py
+++ b/examples/napari_param_sweep.py
@@ -9,6 +9,7 @@ import napari
 import skimage.data
 import skimage.filters
 from napari.layers import Image
+from napari.types import ImageData
 
 from magicgui import magicgui
 
@@ -23,12 +24,14 @@ with napari.gui_qt():
     # - we use `widget_type` to override the default "float" widget on sigma
     # - we provide some Qt-specific parameters
     # - we contstrain the possible choices for `mode`
+    # Note that we aren't returning a napari Image layer, but instead a numpy array
+    # which we want napari to interperate as Image data.
     @magicgui(
         auto_call=True,
         sigma={"widget_type": "FloatSlider", "max": 6},
         mode={"choices": ["reflect", "constant", "nearest", "mirror", "wrap"]},
     )
-    def gaussian_blur(layer: Image, sigma: float = 1.0, mode="nearest") -> Image:
+    def gaussian_blur(layer: Image, sigma: float = 1.0, mode="nearest") -> ImageData:
         """Apply a gaussian blur to ``layer``."""
         if layer:
             return skimage.filters.gaussian(layer.data, sigma=sigma, mode=mode)


### PR DESCRIPTION
This PR will close #153 by fixing the napari return type annotations in the magicgui examples. These were deprecated in https://github.com/napari/napari/pull/2079 and dropped in https://github.com/napari/napari/pull/2198

cc @GenevieveBuckley @jni 