### PR TITLE
Work without numpy

### DIFF
--- a/magicgui/_mpl_image.py
+++ b/magicgui/_mpl_image.py
@@ -55,7 +55,11 @@ import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING, Collection, Union
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError as e:  # pragma: no cover
+    msg = "Numpy required to use images in magicgui: use `pip install magicgui[image]`"
+    raise type(e)(msg) from e
 
 _log = logging.getLogger(__name__)
 

--- a/magicgui/types.py
+++ b/magicgui/types.py
@@ -7,15 +7,10 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Tuple, Type
 
 from typing_extensions import TypedDict
 
-from magicgui._mpl_image import Colormap, Normalize
-
 if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui
     from magicgui.widgets._bases import CategoricalWidget, Widget
     from magicgui.widgets._protocols import WidgetProtocol
-
-
-__all__ = ["Colormap", "Normalize"]
 
 
 #: A :class:`~magicgui.widgets._bases.Widget` class or a

--- a/magicgui/widgets/_image.py
+++ b/magicgui/widgets/_image.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     import PIL.Image
 
     from magicgui import _mpl_image
-    from magicgui.types import Colormap, Normalize
+    from magicgui._mpl_image import Colormap, Normalize
 
     from ._protocols import ValueWidgetProtocol
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -46,4 +46,8 @@ def test_examples(fname):
         with pytest.warns(FutureWarning):
             runpy.run_path(fname)
     else:
-        runpy.run_path(fname)
+        try:
+            runpy.run_path(fname)
+        except ImportError as e:
+            if "Numpy required to use images" in str(e):
+                pytest.skip("numpy unavailable: skipping image example")

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
-import numpy as np
 import pytest
-from numpy.core.numeric import allclose
 
-from magicgui import _mpl_image
 from magicgui.widgets import Image
 
+_mpl_image = pytest.importorskip("magicgui._mpl_image")
+np = pytest.importorskip("numpy")
 pilImage = pytest.importorskip("PIL.Image")
 
 
@@ -97,7 +96,7 @@ def test_internal_cmap():
     )
     rendered2 = image.image_rgba
     assert isinstance(rendered2, np.ndarray)
-    assert not allclose(rendered, rendered2)
+    assert not np.allclose(rendered, rendered2)
 
 
 def test_mpl_cmap():


### PR DESCRIPTION
fixes #161 by removing the `Colormap, Normalize` types from `magicgui.types`  (which snuck through during #140)
