### PR TITLE
fix range/slice edits

### DIFF
--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -22,7 +22,7 @@ class RangedWidget(ValueWidget):
 
     _widget: _protocols.RangedWidgetProtocol
 
-    def __init__(self, min: float = 0, max: float = 100, step: float = 1, **kwargs):
+    def __init__(self, min: float = 0, max: float = 1000, step: float = 1, **kwargs):
         for key in ("maximum", "minimum"):
             if key in kwargs:
                 warn(

--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -40,6 +40,9 @@ class RangedWidget(ValueWidget):
         self.min = min
         self.max = max
         self.step = step
+        if kwargs.get("value") is not None:
+            # value may need to be reset *after* min max is set
+            self.value = kwargs["value"]
 
     @property
     def options(self) -> dict:

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -507,11 +507,11 @@ class RangeEdit(Container):
         elif isinstance(arg, (list, tuple)):
             if not len(arg) == 3:
                 raise ValueError(f"{name} sequence must be length 3")
-            return tuple(cls._validate_min_max(int(x), name, default) for x in arg)
+            return tuple(int(x) for x in arg)
         elif arg is not None:
             raise TypeError("min must be an integer or a 3-tuple of integers")
         else:
-            return (default,) * 3
+            return (int(default),) * 3
 
     @property
     def value(self) -> range:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -461,3 +461,27 @@ def test_main_function_gui():
     assert isinstance(add._help_text_edit, widgets.TextEdit)
     assert add._help_text_edit.value.startswith("Adds the given two numbers")
     assert add._help_text_edit.read_only
+
+
+def test_range_widget():
+    args = (-100, 1000, 2)
+    rw = widgets.RangeEdit(*args)
+    v = rw.value
+    assert isinstance(v, range)
+    assert (v.start, v.stop, v.step) == args
+
+
+def test_range_widget_max():
+    # max will override and restrict the possible values
+    rw = widgets.RangeEdit(-100, 1000, 2, max=(0, 500, 1))
+    v = rw.value
+    assert isinstance(v, range)
+    assert (v.start, v.stop, v.step) == (-100, 500, 1)
+
+
+def test_range_widget_min():
+    # max will override and restrict the possible values
+    rw = widgets.RangeEdit(-100, 1000, 2, min=(0, 500, 5))
+    v = rw.value
+    assert isinstance(v, range)
+    assert (v.start, v.stop, v.step) == (0, 1000, 5)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -144,7 +144,7 @@ def test_basic_widget_attributes():
 
     assert repr(widget) == "SpinBox(value=1, annotation=None, name='my_name')"
     assert widget.options == {
-        "max": 100,
+        "max": 1000,
         "min": 0,
         "step": 1,
         "enabled": False,


### PR DESCRIPTION
fixes #162,
exposes a `min`, `max` argument on Range/SlideEdit sliders that controls the min/max of the `start/stop/stop` sliders.  each accepts a scalar or a 3-tuple of scalars (for start/stop/step).

also made the default layout of a rangeEdit horizontal with labels.