### PR TITLE
Allow callbacks to request event.value directly

### DIFF
--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -355,7 +355,7 @@ class EventEmitter:
     ):
         # connected callbacks
         self._callbacks: List[Union[Callback, CallbackRef]] = []
-        self._callback_wants_event: Dict[Union[Callback, CallbackRef], bool] = {}
+        self._callback_wants_value: Dict[Union[Callback, CallbackRef], bool] = {}
         # used when connecting new callbacks at specific positions
         self._callback_refs: List[Optional[str]] = []
 
@@ -451,7 +451,7 @@ class EventEmitter:
         position: Union[Literal["first"], Literal["last"]] = "first",
         before: Union[str, Callback, List[Union[str, Callback]], None] = None,
         after: Union[str, Callback, List[Union[str, Callback]], None] = None,
-        callback_wants_event: bool = True,
+        callback_wants_value: bool = False,
     ):
         """Connect this emitter to a new callback.
 
@@ -478,10 +478,10 @@ class EventEmitter:
         after : str | callback | list of str or callback | None
             List of callbacks that the current callback should follow.
             Can be None if no after-criteria should be used.
-        callback_wants_event : bool
-            If `True`, callback will receive a single `Event` argument.  If False
+        callback_wants_value : bool
+            If `False`, callback will receive a single `Event` argument.  If `True`
             callback will receive a single argument (the value at `event.value`).  By
-            default, `True`.
+            default, `False`.
 
         Notes
         -----
@@ -571,7 +571,7 @@ class EventEmitter:
 
         # actually add the callback
         self._callbacks.insert(idx, callback)
-        self._callback_wants_event[callback] = callback_wants_event
+        self._callback_wants_value[callback] = callback_wants_value
         self._callback_refs.insert(idx, _ref)
         return callback  # allows connect to be used as a decorator
 
@@ -645,7 +645,7 @@ class EventEmitter:
 
             rem: List[CallbackRef] = []
             for cb in self._callbacks[:]:
-                wants_event = self._callback_wants_event[cb]
+                wants_value = self._callback_wants_value[cb]
                 if isinstance(cb, tuple):
                     obj = cb[0]()
                     if obj is None:
@@ -660,7 +660,7 @@ class EventEmitter:
                     self._block_counter.update([cb])
                     continue
 
-                self._invoke_callback(cb, event, wants_event)
+                self._invoke_callback(cb, event, wants_value)
                 if event.blocked:
                     break
 
@@ -674,11 +674,9 @@ class EventEmitter:
 
         return event
 
-    def _invoke_callback(self, cb: Callback, event: Event, wants_event=True):
+    def _invoke_callback(self, cb: Callback, event: Event, wants_value=True):
         try:
-            if wants_event:
-                cb(event)
-            else:
+            if wants_value:
                 # TODO: big assumption that it has attr 'value'!
                 if hasattr(event, "value"):
                     cb(event.value)
@@ -689,6 +687,8 @@ class EventEmitter:
                         f"callback {cb} requested an event.value, "
                         f"but Event {event} doesn't have a 'value'"
                     )
+            else:
+                cb(event)
         except Exception:
             _handle_exception(
                 self.ignore_callback_errors,
@@ -960,7 +960,7 @@ class EmitterGroup(EventEmitter):
         position: Union[Literal["first"], Literal["last"]] = "first",
         before: Union[str, Callback, List[Union[str, Callback]], None] = None,
         after: Union[str, Callback, List[Union[str, Callback]], None] = None,
-        callback_wants_event: bool = True,
+        callback_wants_value: bool = False,
     ):
         """Connect the callback to the event group. The callback will receive
         events from *all* of the emitters in the group.
@@ -970,7 +970,7 @@ class EmitterGroup(EventEmitter):
         """
         self._connect_emitters(True)
         return EventEmitter.connect(
-            self, callback, ref, position, before, after, callback_wants_event
+            self, callback, ref, position, before, after, callback_wants_value
         )
 
     def disconnect(

--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -679,7 +679,16 @@ class EventEmitter:
             if wants_event:
                 cb(event)
             else:
-                cb(event.value)  # TODO: big assumption that it has attr 'value'!
+                # TODO: big assumption that it has attr 'value'!
+                if hasattr(event, "value"):
+                    cb(event.value)
+                else:
+                    import warnings
+
+                    warnings.warn(
+                        f"callback {cb} requested an event.value, "
+                        f"but Event {event} doesn't have a 'value'"
+                    )
         except Exception:
             _handle_exception(
                 self.ignore_callback_errors,

--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -59,8 +59,21 @@ import logging
 import sys
 import traceback
 import weakref
-from collections import OrderedDict
-from typing import Optional
+from typing import (
+    Any,
+    Callable,
+    Counter,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from typing_extensions import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -123,8 +136,8 @@ def _handle_exception(
     sys.last_traceback = tb
     del tb  # Get rid of it in this namespace
     # Handle
-    if not ignore_callback_errors:
-        raise
+    if value and not ignore_callback_errors:
+        raise value
     if print_callback_errors != "never":
         this_print: Optional[str] = "full"
         if print_callback_errors in ("first", "reminders"):
@@ -162,7 +175,7 @@ def _handle_exception(
                 logger.error("Drawing node {} repeat {}".format(node, this_print))
 
 
-class Event(object):
+class Event:
 
     """Class describing events that occur and can be reacted to with callbacks.
     Each event instance contains information about a single event that has
@@ -187,11 +200,11 @@ class Event(object):
         All extra keyword arguments become attributes of the event object.
     """
 
-    def __init__(self, type, native=None, **kwargs):
+    def __init__(self, type: str, native: Any = None, **kwargs: Any):
         # stack of all sources this event has been emitted through
-        self._sources = []
-        self._handled = False
-        self._blocked = False
+        self._sources: List[Any] = []
+        self._handled: bool = False
+        self._blocked: bool = False
         # Store args
         self._type = type
         self._native = native
@@ -199,12 +212,12 @@ class Event(object):
             setattr(self, k, v)
 
     @property
-    def source(self):
+    def source(self) -> Any:
         """The object that the event applies to (i.e. the source of the event)."""
         return self._sources[-1] if self._sources else None
 
     @property
-    def sources(self):
+    def sources(self) -> List[Any]:
         """List of objects that the event applies to (i.e. are or have
         been a source of the event). Can contain multiple objects in case
         the event traverses a hierarchy of objects.
@@ -218,17 +231,17 @@ class Event(object):
         return self._sources.pop()
 
     @property
-    def type(self):
+    def type(self) -> str:
         # No docstring; documeted in class docstring
         return self._type
 
     @property
-    def native(self):
+    def native(self) -> Any:
         # No docstring; documeted in class docstring
         return self._native
 
     @property
-    def handled(self):
+    def handled(self) -> bool:
         """This boolean property indicates whether the event has already been
         acted on by an event handler. Since many handlers may have access to
         the same events, it is recommended that each check whether the event
@@ -238,11 +251,11 @@ class Event(object):
         return self._handled
 
     @handled.setter
-    def handled(self, val):
+    def handled(self, val) -> None:
         self._handled = bool(val)
 
     @property
-    def blocked(self):
+    def blocked(self) -> bool:
         """This boolean property indicates whether the event will be delivered
         to event callbacks. If it is set to True, then no further callbacks
         will receive the event. When possible, it is recommended to use
@@ -251,10 +264,10 @@ class Event(object):
         return self._blocked
 
     @blocked.setter
-    def blocked(self, val):
+    def blocked(self, val) -> None:
         self._blocked = bool(val)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         # Try to generate a nice string representation of the event that
         # includes the interesting properties.
         # need to keep track of depth because it is
@@ -275,20 +288,28 @@ class Event(object):
                     continue
                 attr = getattr(self, name)
 
-                attrs.append("{}={}".format(name, attr))
+                attrs.append(f"{name}={attr}")
             return "<{} {}>".format(self.__class__.__name__, " ".join(attrs))
         finally:
             _event_repr_depth -= 1
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Shorter string representation"""
         return self.__class__.__name__
+
+    # mypy fix for dynamic attribute access
+    def __getattr__(self, name: str) -> Any:
+        return object.__getattribute__(self, name)
 
 
 _event_repr_depth = 0
 
 
-class EventEmitter(object):
+Callback = Callable[[Event], Any]
+CallbackRef = Tuple["weakref.ReferenceType[Any]", str]  # dereferenced method
+
+
+class EventEmitter:
 
     """Encapsulates a list of event callbacks.
 
@@ -326,12 +347,20 @@ class EventEmitter(object):
         The class of events that this emitter will generate.
     """
 
-    def __init__(self, source=None, type=None, event_class=Event):
-        self._callbacks = []
-        self._callback_refs = []
+    def __init__(
+        self,
+        source: Any = None,
+        type: Optional[str] = None,
+        event_class: Type[Event] = Event,
+    ):
+        # connected callbacks
+        self._callbacks: List[Union[Callback, CallbackRef]] = []
+        # used when connecting new callbacks at specific positions
+        self._callback_refs: List[Optional[str]] = []
 
         # count number of times this emitter is blocked for each callback.
-        self._blocked = {None: 0}
+        self._blocked: Dict[Optional[Callback], int] = {None: 0}
+        self._block_counter: Counter[Optional[Callback]] = Counter()
 
         # used to detect emitter loops
         self._emitting = False
@@ -343,11 +372,11 @@ class EventEmitter(object):
         assert inspect.isclass(event_class)
         self.event_class = event_class
 
-        self._ignore_callback_errors = False  # True
+        self._ignore_callback_errors: bool = False  # True
         self.print_callback_errors = "reminders"  # 'reminders'
 
     @property
-    def ignore_callback_errors(self):
+    def ignore_callback_errors(self) -> bool:
         """Whether exceptions during callbacks will be caught by the emitter
 
         This allows it to continue invoking other callbacks if an error
@@ -356,11 +385,11 @@ class EventEmitter(object):
         return self._ignore_callback_errors
 
     @ignore_callback_errors.setter
-    def ignore_callback_errors(self, val):
+    def ignore_callback_errors(self, val: bool) -> None:
         self._ignore_callback_errors = val
 
     @property
-    def print_callback_errors(self):
+    def print_callback_errors(self) -> str:
         """Print a message and stack trace if a callback raises an exception
 
         Valid values are "first" (only show first instance), "reminders" (show
@@ -374,7 +403,15 @@ class EventEmitter(object):
         return self._print_callback_errors
 
     @print_callback_errors.setter
-    def print_callback_errors(self, val):
+    def print_callback_errors(
+        self,
+        val: Union[
+            Literal["first"],
+            Literal["reminders"],
+            Literal["always"],
+            Literal["never"],
+        ],
+    ):
         if val not in ("first", "reminders", "always", "never"):
             raise ValueError(
                 'print_callback_errors must be "first", '
@@ -383,17 +420,17 @@ class EventEmitter(object):
         self._print_callback_errors = val
 
     @property
-    def callback_refs(self):
+    def callback_refs(self) -> Tuple[Optional[str], ...]:
         """The set of callback references"""
         return tuple(self._callback_refs)
 
     @property
-    def callbacks(self):
+    def callbacks(self) -> Tuple[Union[Callback, CallbackRef], ...]:
         """The set of callbacks"""
         return tuple(self._callbacks)
 
     @property
-    def source(self):
+    def source(self) -> Any:
         """The object that events generated by this emitter apply to"""
         return (
             None if self._source is None else self._source()
@@ -406,7 +443,14 @@ class EventEmitter(object):
         else:
             self._source = weakref.ref(s)
 
-    def connect(self, callback, ref=False, position="first", before=None, after=None):
+    def connect(
+        self,
+        callback: Union[Callback, CallbackRef, "EmitterGroup"],
+        ref: Union[bool, str] = False,
+        position: Union[Literal["first"], Literal["last"]] = "first",
+        before: Union[str, Callback, List[Union[str, Callback]], None] = None,
+        after: Union[str, Callback, List[Union[str, Callback]], None] = None,
+    ):
         """Connect this emitter to a new callback.
 
         Parameters
@@ -463,27 +507,30 @@ class EventEmitter(object):
             return
 
         # deal with the ref
+        _ref: Union[str, None]
         if isinstance(ref, bool):
             if ref:
                 if isinstance(callback, tuple):
-                    ref = callback[1]
+                    _ref = callback[1]
                 elif hasattr(callback, "__name__"):  # function
-                    ref = callback.__name__
+                    _ref = callback.__name__
                 else:  # Method, or other
-                    ref = callback.__class__.__name__
+                    _ref = callback.__class__.__name__
             else:
-                ref = None
-        elif not isinstance(ref, str):
+                _ref = None
+        elif isinstance(ref, str):
+            _ref = ref
+        else:
             raise TypeError("ref must be a bool or string")
-        if ref is not None and ref in self._callback_refs:
-            raise ValueError('ref "%s" is not unique' % ref)
+        if _ref is not None and _ref in self._callback_refs:
+            raise ValueError('ref "%s" is not unique' % _ref)
 
         # positions
         if position not in ("first", "last"):
             raise ValueError('position must be "first" or "last", not %s' % position)
 
-        # bounds
-        bounds = list()  # upper & lower bnds (inclusive) of possible cb locs
+        # bounds: upper & lower bnds (inclusive) of possible cb locs
+        bounds: List[int] = list()
         for ri, criteria in enumerate((before, after)):
             if criteria is None or criteria == []:
                 bounds.append(len(callback_refs) if ri == 0 else 0)
@@ -518,10 +565,12 @@ class EventEmitter(object):
 
         # actually add the callback
         self._callbacks.insert(idx, callback)
-        self._callback_refs.insert(idx, ref)
+        self._callback_refs.insert(idx, _ref)
         return callback  # allows connect to be used as a decorator
 
-    def disconnect(self, callback=None):
+    def disconnect(
+        self, callback: Union["EmitterGroup", Callback, CallbackRef, None] = None
+    ):
         """Disconnect a callback from this emitter.
 
         If no callback is specified, then *all* callbacks are removed.
@@ -537,7 +586,7 @@ class EventEmitter(object):
                 self._callbacks.pop(idx)
                 self._callback_refs.pop(idx)
 
-    def _normalize_cb(self, callback):
+    def _normalize_cb(self, callback) -> Union[CallbackRef, Callback]:
         # dereference methods into a (self, method_name) pair so that we can
         # make the connection without making a strong reference to the
         # instance.
@@ -550,7 +599,7 @@ class EventEmitter(object):
 
         return callback
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Event:
         """__call__(**kwargs)
         Invoke all callbacks for this emitter.
 
@@ -584,20 +633,23 @@ class EventEmitter(object):
         self._emitting = True
         try:
             if blocked.get(None, 0) > 0:  # this is the same as self.blocked()
+                self._block_counter.update([None])
                 return event
 
-            rem = []
+            rem: List[CallbackRef] = []
             for cb in self._callbacks[:]:
                 if isinstance(cb, tuple):
                     obj = cb[0]()
                     if obj is None:
-                        rem.append(cb)
+                        rem.append(cb)  # add dead weakref
                         continue
                     cb = getattr(obj, cb[1], None)
                     if cb is None:
                         continue
+                    cb = cast(Callback, cb)
 
                 if blocked.get(cb, 0) > 0:
+                    self._block_counter.update([cb])
                     continue
 
                 self._invoke_callback(cb, event)
@@ -614,7 +666,7 @@ class EventEmitter(object):
 
         return event
 
-    def _invoke_callback(self, cb, event):
+    def _invoke_callback(self, cb: Callback, event: Event):
         try:
             cb(event)
         except Exception:
@@ -625,18 +677,18 @@ class EventEmitter(object):
                 cb_event=(cb, event),
             )
 
-    def _prepare_event(self, *args, **kwargs):
+    def _prepare_event(self, *args, **kwargs) -> Event:
         # When emitting, this method is called to create or otherwise alter
         # an event before it is sent to callbacks. Subclasses may extend
         # this method to make custom modifications to the event.
         if len(args) == 1 and not kwargs and isinstance(args[0], Event):
-            event = args[0]
+            event: Event = args[0]
             # Ensure that the given event matches what we want to emit
             assert isinstance(event, self.event_class)
         elif not args:
-            _args = self.default_args.copy()
-            _args.update(kwargs)
-            event = self.event_class(**_args)
+            _kwargs = self.default_args.copy()
+            _kwargs.update(kwargs)
+            event = self.event_class(**_kwargs)
         else:
             raise ValueError(
                 "Event emitters can be called with an Event "
@@ -644,13 +696,13 @@ class EventEmitter(object):
             )
         return event
 
-    def blocked(self, callback=None):
+    def blocked(self, callback: Optional[Callback] = None) -> bool:
         """Return boolean indicating whether the emitter is blocked for
         the given callback.
         """
         return self._blocked.get(callback, 0) > 0
 
-    def block(self, callback=None):
+    def block(self, callback: Optional[Callback] = None):
         """Block this emitter. Any attempts to emit an event while blocked
         will be silently ignored. If *callback* is given, then the emitter
         is only blocked for that specific callback.
@@ -660,7 +712,7 @@ class EventEmitter(object):
         """
         self._blocked[callback] = self._blocked.get(callback, 0) + 1
 
-    def unblock(self, callback=None):
+    def unblock(self, callback: Optional[Callback] = None):
         """Unblock this emitter. See :func:`event.EventEmitter.block`.
 
         Note: Use of ``unblock(None)`` only reverses the effect of
@@ -678,7 +730,7 @@ class EventEmitter(object):
         else:
             self._blocked[callback] = b
 
-    def blocker(self, callback=None):
+    def blocker(self, callback: Optional[Callback] = None):
         """Return an EventBlocker to be used in 'with' statements
 
         Notes
@@ -761,17 +813,25 @@ class EmitterGroup(EventEmitter):
         See the :func:`add <vispy.event.EmitterGroup.add>` method.
     """
 
-    def __init__(self, source=None, auto_connect=True, **emitters):
+    def __init__(
+        self,
+        source: Any = None,
+        auto_connect: bool = True,
+        **emitters: Union[Type[Event], EventEmitter, None],
+    ):
         EventEmitter.__init__(self, source)
 
         self.auto_connect = auto_connect
         self.auto_connect_format = "on_%s"
-        self._emitters = OrderedDict()
+        self._emitters: Dict[str, EventEmitter] = dict()
         # whether the sub-emitters have been connected to the group:
-        self._emitters_connected = False
-        self.add(**emitters)
+        self._emitters_connected: bool = False
+        self.add(**emitters)  # type: ignore
 
-    def __getitem__(self, name):
+    def __getattr__(self, name) -> EventEmitter:
+        return object.__getattribute__(self, name)
+
+    def __getitem__(self, name: str) -> EventEmitter:
         """
         Return the emitter assigned to the specified name.
         Note that emitters may also be retrieved as an attribute of the
@@ -779,13 +839,17 @@ class EmitterGroup(EventEmitter):
         """
         return self._emitters[name]
 
-    def __setitem__(self, name, emitter):
+    def __setitem__(self, name: str, emitter: Union[Type[Event], EventEmitter, None]):
         """
         Alias for EmitterGroup.add(name=emitter)
         """
-        self.add(**{name: emitter})
+        self.add(**{name: emitter})  # type: ignore
 
-    def add(self, auto_connect=None, **kwargs):
+    def add(
+        self,
+        auto_connect: Optional[bool] = None,
+        **kwargs: Union[Type[Event], EventEmitter, None],
+    ):
         """Add one or more EventEmitter instances to this emitter group.
         Each keyword argument may be specified as either an EventEmitter
         instance or an Event subclass, in which case an EventEmitter will be
@@ -821,9 +885,9 @@ class EmitterGroup(EventEmitter):
             if emitter is None:
                 emitter = Event
 
-            if inspect.isclass(emitter) and issubclass(emitter, Event):
+            if inspect.isclass(emitter) and issubclass(emitter, Event):  # type: ignore
                 emitter = EventEmitter(
-                    source=self.source, type=name, event_class=emitter
+                    source=self.source, type=name, event_class=emitter  # type: ignore
                 )
             elif not isinstance(emitter, EventEmitter):
                 raise Exception(
@@ -835,7 +899,7 @@ class EmitterGroup(EventEmitter):
             # give this emitter the same source as the group.
             emitter.source = self.source
 
-            setattr(self, name, emitter)
+            setattr(self, name, emitter)  # this is a bummer for typing.
             self._emitters[name] = emitter
 
             if auto_connect and self.source is not None:
@@ -847,16 +911,15 @@ class EmitterGroup(EventEmitter):
                 emitter.connect(self)
 
     @property
-    def emitters(self):
+    def emitters(self) -> Dict[str, EventEmitter]:
         """List of current emitters in this group."""
         return self._emitters
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[str, None, None]:
         """
         Iterates over the names of emitters in this group.
         """
-        for k in self._emitters:
-            yield k
+        yield from self._emitters
 
     def block_all(self):
         """Block all emitters in this group."""
@@ -870,7 +933,14 @@ class EmitterGroup(EventEmitter):
         for em in self._emitters.values():
             em.unblock()
 
-    def connect(self, callback, ref=False, position="first", before=None, after=None):
+    def connect(
+        self,
+        callback: Union[Callback, CallbackRef, "EmitterGroup"],
+        ref: Union[bool, str] = False,
+        position: Union[Literal["first"], Literal["last"]] = "first",
+        before: Union[str, Callback, List[Union[str, Callback]], None] = None,
+        after: Union[str, Callback, List[Union[str, Callback]], None] = None,
+    ):
         """Connect the callback to the event group. The callback will receive
         events from *all* of the emitters in the group.
 
@@ -880,7 +950,9 @@ class EmitterGroup(EventEmitter):
         self._connect_emitters(True)
         return EventEmitter.connect(self, callback, ref, position, before, after)
 
-    def disconnect(self, callback=None):
+    def disconnect(
+        self, callback: Union["EmitterGroup", Callback, CallbackRef, None] = None
+    ):
         """Disconnect the callback from this group. See
         :func:`connect() <vispy.event.EmitterGroup.connect>` and
         :func:`EventEmitter.connect() <vispy.event.EventEmitter.connect>` for
@@ -915,10 +987,22 @@ class EmitterGroup(EventEmitter):
             if isinstance(emitter, EventEmitter):
                 emitter.ignore_callback_errors = ignore
             elif isinstance(emitter, EmitterGroup):
-                emitter.ignore_callback_errors_all(ignore)  # type: ignore
+                emitter.ignore_callback_errors_all(ignore)
+
+    def blocker_all(self) -> "EventBlockerAll":
+        """Return an EventBlockerAll to be used in 'with' statements
+
+        Notes
+        -----
+        For example, one could do::
+
+            with emitter.blocker_all():
+                pass  # ..do stuff; no events will be emitted..
+        """
+        return EventBlockerAll(self)
 
 
-class EventBlocker(object):
+class EventBlocker:
 
     """Represents a block for an EventEmitter to be used in a context
     manager (i.e. 'with' statement).
@@ -927,9 +1011,32 @@ class EventBlocker(object):
     def __init__(self, target, callback=None):
         self.target = target
         self.callback = callback
+        self._base_count = target._block_counter.get(callback, 0)
+
+    @property
+    def count(self):
+        n_blocked = self.target._block_counter.get(self.callback, 0)
+        return n_blocked - self._base_count
 
     def __enter__(self):
         self.target.block(self.callback)
+        return self
 
     def __exit__(self, *args):
         self.target.unblock(self.callback)
+
+
+class EventBlockerAll:
+
+    """Represents a block_all for an EmitterGroup to be used in a context
+    manager (i.e. 'with' statement).
+    """
+
+    def __init__(self, target):
+        self.target = target
+
+    def __enter__(self):
+        self.target.block_all()
+
+    def __exit__(self, *args):
+        self.target.unblock_all()

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -188,7 +188,7 @@ class ValueWidgetProtocol(WidgetProtocol, Protocol):
         raise NotImplementedError()
 
     @abstractmethod
-    def _mgui_bind_change_callback(self, callback: Callable[[Any], None]) -> None:
+    def _mgui_bind_change_callback(self, callback: Callable[[Any], Any]) -> None:
         """Bind callback to value change event."""
         raise NotImplementedError()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,10 @@ add_select = D402,D415,D417
 ignore = D100, D213, D401, D413, D107
 
 [tool:pytest]
-addopts = -v -W error --mypy-ini-file=setup.cfg
+addopts = -v --mypy-ini-file=setup.cfg
+filterwarnings =
+    error:::magicgui.
+    ignore:magicgui 0.3.0:FutureWarning
 
 [mypy]
 files = magicgui

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -676,6 +676,8 @@ def test_emitter_block2():
 def test_alternate_callback_signature():
     from unittest.mock import Mock
 
+    import pytest
+
     callback_a = Mock()
     callback_b = Mock()
     em = EventEmitter(type="test")
@@ -686,3 +688,6 @@ def test_alternate_callback_signature():
 
     callback_a.assert_called_once_with(event)
     callback_b.assert_called_once_with(1)
+
+    with pytest.warns(UserWarning):
+        em()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -170,7 +170,7 @@ def test_emitter_type_event_class():
             pass
 
     try:
-        em = EventEmitter(event_class=X)
+        em = EventEmitter(event_class=X)  # type: ignore
         ev = try_emitter(em, type="test_event")
         record_event.assert_result()  # checks event type
         assert False, "Should not be able to construct emitter with non-Event class"
@@ -207,7 +207,7 @@ def test_emitter_subclass():
     class MyEmitter(EventEmitter):
         def _prepare_event(self, *args, **kwargs):
             ev = super(MyEmitter, self)._prepare_event(*args, **kwargs)
-            ev.test_tag = 1
+            ev.test_tag = 1  # type: ignore
             return ev
 
     em = MyEmitter(type="test_event")
@@ -240,7 +240,7 @@ def test_disconnect():
     def cb2(ev):
         record_event.result = 2
 
-    em.connect((record_event, "__call__"))
+    em.connect((record_event, "__call__"))  # type: ignore
     em.connect(cb1)
     em.connect(cb2)
     record_event.result = None
@@ -250,14 +250,14 @@ def test_disconnect():
     record_event.assert_result(event=ev)
 
     record_event.result = None
-    em.disconnect((record_event, "__call__"))
+    em.disconnect((record_event, "__call__"))  # type: ignore
     ev = em()
     assert record_event.result == 1
 
     record_event.result = None
     em.connect(cb1)
     em.connect(cb2)
-    em.connect((record_event, "__call__"))
+    em.connect((record_event, "__call__"))  # type: ignore
     em.disconnect()
     em()
     assert record_event.result is None
@@ -488,22 +488,22 @@ def test_event_block():
 def test_event_connect_order():
     """Test event connection order"""
 
-    def a():
+    def a(e):
         return
 
-    def b():
+    def b(e):
         return
 
-    def c():
+    def c(e):
         return
 
-    def d():
+    def d(e):
         return
 
-    def e():
+    def e(e):
         return
 
-    def f():
+    def f(e):
         return
 
     em = EventEmitter(type="test_event")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -682,7 +682,7 @@ def test_alternate_callback_signature():
     callback_b = Mock()
     em = EventEmitter(type="test")
     em.connect(callback_a)
-    em.connect(callback_b, callback_wants_event=False)
+    em.connect(callback_b, callback_wants_value=True)
 
     event = em(value=1)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -671,3 +671,18 @@ def test_emitter_block2():
 
     e()
     assert_state(True, True)
+
+
+def test_alternate_callback_signature():
+    from unittest.mock import Mock
+
+    callback_a = Mock()
+    callback_b = Mock()
+    em = EventEmitter(type="test")
+    em.connect(callback_a)
+    em.connect(callback_b, callback_wants_event=False)
+
+    event = em(value=1)
+
+    callback_a.assert_called_once_with(event)
+    callback_b.assert_called_once_with(1)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -682,7 +682,7 @@ def test_alternate_callback_signature():
     callback_b = Mock()
     em = EventEmitter(type="test")
     em.connect(callback_a)
-    em.connect(callback_b, callback_wants_value=True)
+    em.connect(callback_b, callback_wants_event=False)
 
     event = em(value=1)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5,8 +5,6 @@ import copy
 import functools
 from typing import Any
 
-import pytest
-
 from magicgui.events import Event, EventEmitter
 
 
@@ -283,15 +281,13 @@ def test_decorator_connection():
     """Connection by decorator"""
     em = EventEmitter(type="test_event")
 
-    with pytest.raises(FutureWarning):
+    @em.connect
+    def cb(ev):
+        record_event.result = 1
 
-        @em.connect
-        def cb(ev):
-            record_event.result = 1
-
-        record_event.result = None
-        em()
-        assert record_event.result == 1
+    record_event.result = None
+    em()
+    assert record_event.result == 1
 
 
 def test_chained_emitters():
@@ -511,12 +507,9 @@ def test_event_connect_order():
         return
 
     em = EventEmitter(type="test_event")
-    with pytest.raises(FutureWarning):
-        assert_raises(ValueError, em.connect, c, before=["c", "foo"])
-    with pytest.raises(FutureWarning):
-        assert_raises(ValueError, em.connect, c, position="foo")
-    with pytest.raises(FutureWarning):
-        assert_raises(TypeError, em.connect, c, ref=dict())
+    assert_raises(ValueError, em.connect, c, before=["c", "foo"])
+    assert_raises(ValueError, em.connect, c, position="foo")
+    assert_raises(TypeError, em.connect, c, ref=dict())
     em.connect(c, ref=True, callback_wants_event=True)
     assert_equal((c,), tuple(em.callbacks))
     em.connect(c, callback_wants_event=True)
@@ -525,8 +518,8 @@ def test_event_connect_order():
     assert_equal((c, d), tuple(em.callbacks))
     em.connect(b, ref=True, callback_wants_event=True)  # position='first'
     assert_equal((b, c, d), tuple(em.callbacks))
-    with pytest.raises(FutureWarning):
-        assert_raises(RuntimeError, em.connect, a, before="c", after="d")  # can't
+
+    assert_raises(RuntimeError, em.connect, a, before="c", after="d")  # can't
     em.connect(
         a, ref=True, before=["c", "d"], callback_wants_event=True
     )  # first possible pos == 0
@@ -551,8 +544,8 @@ def test_event_connect_order():
     )  # no name
     assert_equal(("a", "b", "c", "d", None, "f"), tuple(em.callback_refs))
     em.disconnect(e)
-    with pytest.raises(FutureWarning):
-        assert_raises(ValueError, em.connect, e, ref="d")  # duplicate name
+
+    assert_raises(ValueError, em.connect, e, ref="d")  # duplicate name
     em.connect(
         e, ref=True, after=[], before="f", position="last", callback_wants_event=True
     )
@@ -564,8 +557,7 @@ def test_event_connect_order():
     def e():  # type: ignore
         return
 
-    with pytest.raises(FutureWarning):
-        assert_raises(ValueError, em.connect, e, ref=True)  # duplicate name
+    assert_raises(ValueError, em.connect, e, ref=True)  # duplicate name
     em.connect(e, callback_wants_event=True)
     assert_equal((None, "a", "b", "c", "d", "e", "f"), tuple(em.callback_refs))
     assert_equal((e, a, b, c, d, old_e, f), tuple(em.callbacks))


### PR DESCRIPTION
This is a proposal to address #173.  The event system (inherited from vispy, also used by napari) has the design that callbacks receive a single `Event` object, and must inspect that event object for things like `event.value` that they want to use.  Internally, that makes the `Event` object super flexible, but – as pointed out in #173 – for an end-user connecting callbacks, it probably almost always feels like an unnecessary layer.  This PR adds a backwards compatible, opt-in mechanism that would allow a callback to indicate that it wants `event.value` rather than `event`.

```python
from magicgui.events import EventEmitter

em = EventEmitter(type='test')
em.connect(print, callback_wants_value=True)
em(value=1)  # prints '1'
```

This behaves more like Qt Signals and Slots, where the slot/callback receives actual values, rather than some wrapper object.  One problem, of course, is that, internally, it _requires_ the event emitter to be called with `emitter(value=something)`.  Currently, _all_ events in magicgui follow that convention, so this PR doesn't go farther to impose any EventEmitter checking for compatibility with the `callback_wants_value` option.  (If a callback has requested value, and the even doesn't provide one, it currently just fails with a warning, rather than an exception).

@sofroniewn, @jni  ... since this is a concept that may well affect napari in the longer term (if we want to provide a more friendly callback-connecting API), curious to get your thoughts