### PR TITLE
Fix RadioButtons double event emissions

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -551,10 +551,9 @@ class RadioButtons(
         self._mgui_set_orientation("vertical")
         self._btn_group.buttonToggled.connect(self._emit_data)
 
-    def _emit_data(self, btn):
-        data = self._mgui_get_value()
-        if data is not None:
-            self._event_filter.valueChanged.emit(data)
+    def _emit_data(self, btn, checked):
+        if checked:
+            self._event_filter.valueChanged.emit(self._mgui_get_value())
 
     def _mgui_bind_change_callback(self, callback):
         self._event_filter.valueChanged.connect(callback)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -541,10 +541,15 @@ def test_categorical_widgets(Cls):
         value=1,
         choices=[("first option", 1), ("second option", 2), ("third option", 3)],
     )
+
+    wdg.changed = MagicMock(wraps=wdg.changed)
     assert isinstance(wdg, widgets._bases.CategoricalWidget)
     assert wdg.value == 1
     assert wdg.current_choice == "first option"
+    wdg.changed.assert_not_called()
     wdg.value = 2
+    wdg.changed.assert_called_once()
+    assert wdg.changed.call_args[1].get("value") == 2
     assert wdg.value == 2
     assert wdg.current_choice == "second option"
     assert wdg.choices == (1, 2, 3)


### PR DESCRIPTION
fixes #188

This introduces a new problem, which is that if someone programmatically sets `widget.value` to `None`, then no event will be emitted (in the GUI, this isn't possible since once a radio button is checked it can't be unchecked).  quick solutions to this are made slightly challenging by the fact that we don't know if a _non-None_ value is about to be set in the near future.  Anyway, that's probably less problematic than the current behavior, so we'll leave that fix for a later PR.