### PR TITLE
fix enum choices in radiobuttons

### DIFF
--- a/magicgui/type_map.py
+++ b/magicgui/type_map.py
@@ -166,20 +166,21 @@ def pick_widget_type(
     value: Any = None, annotation: type | None = None, options: WidgetOptions = {}
 ) -> WidgetTuple:
     """Pick the appropriate widget type for ``value`` with ``annotation``."""
+    annotation = _evaluate_forwardref(annotation)
+    dtype = _normalize_type(value, annotation)
+    choices = options.get("choices") or (isinstance(dtype, EnumMeta) and dtype)
+
     if "widget_type" in options:
         widget_type = options.pop("widget_type")
+        if choices:
+            options.setdefault("choices", choices)
         return widget_type, options
-
-    annotation = _evaluate_forwardref(annotation)
-
-    dtype = _normalize_type(value, annotation)
 
     # look for subclasses
     for registered_type in _TYPE_DEFS:
         if dtype == registered_type or _is_subclass(dtype, registered_type):
             return _TYPE_DEFS[registered_type]
 
-    choices = options.get("choices") or (isinstance(dtype, EnumMeta) and dtype)
     if choices:
         return widgets.ComboBox, {"choices": choices}
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,4 +1,5 @@
 import inspect
+from enum import Enum
 from unittest.mock import MagicMock
 
 import pytest
@@ -556,6 +557,28 @@ def test_categorical_widgets(Cls):
 
     wdg.del_choice("third option")
     assert wdg.choices == (1, 2)
+
+
+class MyEnum(Enum):
+    A = "a"
+    B = "b"
+
+
+@pytest.mark.parametrize("Cls", [widgets.ComboBox, widgets.RadioButtons])
+def test_categorical_widgets_with_enums(Cls):
+    wdg = Cls(value=MyEnum.A, choices=MyEnum)
+
+    wdg.changed = MagicMock(wraps=wdg.changed)
+    assert isinstance(wdg, widgets._bases.CategoricalWidget)
+    assert wdg.value == MyEnum.A
+    assert wdg.current_choice == "A"
+    wdg.changed.assert_not_called()
+    wdg.value = MyEnum.B
+    wdg.changed.assert_called_once()
+    assert wdg.changed.call_args[1].get("value") == MyEnum.B
+    assert wdg.value == MyEnum.B
+    assert wdg.current_choice == "B"
+    assert wdg.choices == tuple(MyEnum.__members__.values())
 
 
 @pytest.mark.skipif(not use_app().backend_name == "qt", reason="only on qt")

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -581,7 +581,7 @@ def test_categorical_widgets_with_enums(Cls):
     assert wdg.choices == tuple(MyEnum.__members__.values())
 
 
-@pytest.mark.skipif(not use_app().backend_name == "qt", reason="only on qt")
+@pytest.mark.skipif(use_app().backend_name != "qt", reason="only on qt")
 def test_radiobutton_reset_choices():
     """Test that reset_choices doesn't change the number of buttons."""
     from qtpy.QtWidgets import QRadioButton


### PR DESCRIPTION
this fixes a bug that @jni encountered wherein `RadioButtons` used with Enums weren't being populated with choices  