### PR TITLE
Fix persist issue with cached parameter that has been removed

### DIFF
--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -308,7 +308,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
                 continue
             try:
                 getattr(self, key).value = val
-            except ValueError:
+            except (ValueError, AttributeError):
                 pass
 
 


### PR DESCRIPTION
This fixes the issue when a parameter is first persisted by running:
```python
from magicgui import magicgui
@magicgui(persist=True)
def func(x: int):
    pass
func.x.value = 42
```
The parameter is later removed from `func` and restoring it fails with an `AttributeError` when running:
```python
from magicgui import magicgui
@magicgui(persist=True)
def func():
    pass
```
```python
Traceback (most recent call last):
  File "/home/uwe/research/stardist/napari/dev.py", line 126, in <module>
    def func():
  File "/home/uwe/research/stardist/napari/magicgui/magicgui/_magicgui.py", line 240, in inner_func
    return magic_class(func, **kwargs)
  File "/home/uwe/research/stardist/napari/magicgui/magicgui/widgets/_function_gui.py", line 201, in __init__
    self._load(quiet=True)
  File "/home/uwe/research/stardist/napari/magicgui/magicgui/widgets/_function_gui.py", line 380, in _load
    super()._load(path or self._dump_path, quiet=quiet)
  File "/home/uwe/research/stardist/napari/magicgui/magicgui/widgets/_bases/container_widget.py", line 310, in _load
    getattr(self, key).value = val
  File "/home/uwe/research/stardist/napari/magicgui/magicgui/widgets/_bases/container_widget.py", line 84, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'FunctionGui' object has no attribute 'x'
```