### PR TITLE
Disconnect filedialog button from value.changed events

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ jupytext
 numpy
 imageio
 sphinx-autodoc-typehints
-sphinxcontrib-bibtex>=2.2.0
+sphinxcontrib-bibtex<2.0.0

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -481,8 +481,9 @@ class FileEdit(Container):
         super().__init__(**kwargs)
         self.margins = (0, 0, 0, 0)
         self._show_file_dialog = use_app().get_obj("show_file_dialog")
-        self.choose_btn.changed.connect(self._on_choose_clicked)
+        self.choose_btn.changed.disconnect()
         self.line_edit.changed.disconnect()
+        self.choose_btn.changed.connect(self._on_choose_clicked)
         self.line_edit.changed.connect(lambda x: self.changed(value=self.value))
 
     @property
@@ -527,7 +528,7 @@ class FileEdit(Container):
     def value(self, value: Sequence[PathLike] | PathLike):
         """Set current file path."""
         if isinstance(value, (list, tuple)):
-            value = ", ".join([os.fspath(p) for p in value])
+            value = ", ".join(os.fspath(p) for p in value)
         if not isinstance(value, (str, Path)):
             raise TypeError(
                 f"value must be a string, or list/tuple of strings, got {type(value)}"

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,7 @@
 import inspect
 from enum import Enum
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from tests import MyInt
@@ -510,12 +511,20 @@ def test_containers_show_nested_containers():
 
 def test_file_dialog_events():
     """Test that file dialog events emit the value of the line_edit."""
-    from pathlib import Path
-
     fe = widgets.FileEdit(value="hi")
     fe.changed = MagicMock(wraps=fe.changed)
     fe.line_edit.value = "world"
     fe.changed.assert_called_once_with(value=Path("world"))
+
+
+def test_file_dialog_button_events():
+    """Test that clicking the file dialog button doesn't emit an event."""
+    fe = widgets.FileEdit(value="hi")
+    fe.changed = MagicMock(wraps=fe.changed)
+    with patch.object(fe, "_show_file_dialog", return_value=""):
+        fe.choose_btn.changed()
+    fe.changed.assert_not_called()
+    assert fe.value == Path("hi")
 
 
 @pytest.mark.parametrize("WdgClass", [widgets.FloatSlider, widgets.FloatSpinBox])


### PR DESCRIPTION
fixes #204 by disconnecting the filedialog button from creating change events (only changes to the LineEdit itself should affect `file_widget.changed`)