### PR TITLE
Add table.changed event emitter

### DIFF
--- a/examples/table.py
+++ b/examples/table.py
@@ -58,4 +58,7 @@ table.data[2, ::2] = [99, 99]
 # table.data.to_numpy()
 # table.to_dataframe()
 
+# the table.changed event emits a dict of information on any cell change
+# e.g. {'data': 'sdfg', 'row': 1, 'column': 0, 'column_header': '1', 'row_header': '1'}
+table.changed.connect(lambda e: print(e.value))
 table.show(run=True)

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -825,8 +825,10 @@ class Table(QBaseWidget, _protocols.TableWidgetProtocol):
         """Bind callback to event of changing any cell."""
 
         def _item_callback(item, callback=callback):
-            col_head = item.tableWidget().horizontalHeaderItem(item.column()).text()
-            row_head = item.tableWidget().verticalHeaderItem(item.row()).text()
+            col_head = item.tableWidget().horizontalHeaderItem(item.column())
+            col_head = col_head.text() if col_head is not None else ""
+            row_head = item.tableWidget().verticalHeaderItem(item.row())
+            row_head = row_head.text() if row_head is not None else ""
             data = {
                 "data": item.data(self._DATA_ROLE),
                 "row": item.row(),

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -821,12 +821,19 @@ class Table(QBaseWidget, _protocols.TableWidgetProtocol):
         """Bind callback to column headers change event."""
         raise NotImplementedError()
 
-    def _mgui_bind_cell_change_callback(self, callback) -> None:
-        """Bind callback to column headers change event."""
-        raise NotImplementedError()
-
     def _mgui_bind_change_callback(self, callback):
-        # FIXME: this currently reads out the WHOLE table every time we change ANY cell.
-        # nonsense.
-        # self._qwidget.itemChanged.connect(lambda i: callback(self._mgui_get_value()))
-        pass
+        """Bind callback to event of changing any cell."""
+
+        def _item_callback(item, callback=callback):
+            col_head = item.tableWidget().horizontalHeaderItem(item.column()).text()
+            row_head = item.tableWidget().verticalHeaderItem(item.row()).text()
+            data = {
+                "data": item.data(self._DATA_ROLE),
+                "row": item.row(),
+                "column": item.column(),
+                "column_header": col_head,
+                "row_header": row_head,
+            }
+            callback(data)
+
+        self._qwidget.itemChanged.connect(_item_callback)

--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -661,8 +661,11 @@ class EventEmitter:
                 self.disconnect(cb)
         finally:
             self._emitting = False
-            if event._pop_source() != self.source:
-                raise RuntimeError("Event source-stack mismatch.")
+            evsource = event._pop_source()
+            if evsource is not self.source:
+                raise RuntimeError(
+                    f"Event source-stack mismatch. ({evsource} is not {self.source}"
+                )
 
         return event
 

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -272,8 +272,8 @@ class TableWidgetProtocol(WidgetProtocol, Protocol):
         raise NotImplementedError()
 
     @abstractmethod
-    def _mgui_bind_cell_change_callback(self, callback: Callable[[Any], None]) -> None:
-        """Bind callback to column headers change event."""
+    def _mgui_bind_change_callback(self, callback: Callable[[Any], Any]) -> None:
+        """Bind callback to value change event."""
         raise NotImplementedError()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+# for now, the only backend is qt, and pytest-qt's qapp provides some nice pre-post
+# test cleanup that prevents some segfaults.  Once we start testing multiple backends
+# this will need to change.
+@pytest.fixture(autouse=True, scope="session")
+def always_qapp(qapp):
+    return qapp

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -395,7 +395,7 @@ def test_source_stack_integrity():
     try:
         em()
     except RuntimeError as err:
-        if str(err) != "Event source-stack mismatch.":
+        if "Event source-stack mismatch." not in str(err):
             raise
 
     em.disconnect()


### PR DESCRIPTION
closes #205 by adding a `table_widget.changed` eventEmitter.

with `table_widget.changed.connect(callback)`, the `callback` function will receive an event (whenver any item of the table changes in the GUI), and the `event.value` will be a dict:
`{'data': x, 'row': int, 'column': int, 'column_header': str, 'row_header': str}`