### PR TITLE
Fix EventEmitter loop when event is blocked

### DIFF
--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -58,6 +58,7 @@ import inspect
 import logging
 import sys
 import traceback
+import warnings
 import weakref
 from typing import (
     Any,
@@ -625,7 +626,8 @@ class EventEmitter:
             self._block_counter.update([None])
             return None
         elif self._emitting:
-            raise RuntimeError("EventEmitter loop detected!")
+            warnings.warn("EventEmitter loop detected!")
+            return None
 
         # create / massage event as needed
         event = self._prepare_event(*args, **kwargs)
@@ -773,7 +775,7 @@ class WarningEmitter(EventEmitter):
             return
 
         traceback.print_stack()
-        logger.warning(self._message)
+        warnings.warn(self._message)
         self._warned = True
 
 

--- a/magicgui/widgets/_bases/value_widget.py
+++ b/magicgui/widgets/_bases/value_widget.py
@@ -40,9 +40,11 @@ class ValueWidget(Widget):
     def _post_init(self):
         super()._post_init()
         self.changed = EventEmitter(source=self, type="changed")
-        self._widget._mgui_bind_change_callback(
-            lambda *x: self.changed(value=x[0] if x else None)
-        )
+        self._widget._mgui_bind_change_callback(self._on_value_change)
+
+    def _on_value_change(self, *args):
+        """Called when the widget value changes.  args come from the widget itself."""
+        self.changed(value=args[0] if args else None)
 
     def get_value(self):
         """Callable version of `self.value`.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5,6 +5,8 @@ import copy
 import functools
 from typing import Any
 
+import pytest
+
 from magicgui.events import Event, EventEmitter
 
 
@@ -422,11 +424,9 @@ def test_emitter_loop():
     # indicating an event loop.
     em1.connect(em2)
     em2.connect(em1)
-    try:
+    with pytest.warns(UserWarning) as record:
         em1()
-    except RuntimeError as err:
-        if str(err) != "EventEmitter loop detected!":
-            raise err
+    assert "EventEmitter loop detected!" in str(record[0].message)
 
 
 def test_emitter_block1():


### PR DESCRIPTION
Fixes #187 

got it figured out @uschmidt83.  The blocker wasn't aborting the event call before the exception was raised.  (surprised it only happened in certain contexts!).  thanks again for the example.d