### PR TITLE
Add `tracking` property to sliders.  When False, changed only emits on release.

### DIFF
--- a/examples/log_slider.py
+++ b/examples/log_slider.py
@@ -5,7 +5,7 @@ from magicgui import magicgui
 @magicgui(
     auto_call=True,
     result_widget=True,
-    input={"widget_type": "LogSlider", "max": 10000, "min": 1},
+    input={"widget_type": "LogSlider", "max": 10000, "min": 1, "tracking": False},
 )
 def slider(input=1):
     return round(input, 4)

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -477,6 +477,17 @@ class _Slider(QBaseRangedWidget, _protocols.SupportsOrientation):
     def _mgui_set_readout_visibility(self, value: bool):
         raise NotImplementedError()
 
+    def _mgui_get_tracking(self) -> bool:
+        # Progressbar also uses this base, but doesn't have tracking
+        if hasattr(self._qwidget, "hasTracking"):
+            return self._qwidget.hasTracking()
+        return False
+
+    def _mgui_set_tracking(self, value: bool) -> None:
+        # Progressbar also uses this base, but doesn't have tracking
+        if hasattr(self._qwidget, "setTracking"):
+            self._qwidget.setTracking(value)
+
 
 class Slider(_Slider):
     _qwidget: QtW.QSlider

--- a/magicgui/widgets/_bases/slider_widget.py
+++ b/magicgui/widgets/_bases/slider_widget.py
@@ -15,10 +15,29 @@ class SliderWidget(RangedWidget, _OrientationMixin):
 
     _widget: _protocols.SliderWidgetProtocol
 
-    def __init__(self, orientation: str = "horizontal", readout=True, **kwargs):
+    def __init__(
+        self, orientation: str = "horizontal", readout=True, tracking=True, **kwargs
+    ):
         kwargs["backend_kwargs"] = {"readout": readout, "orientation": orientation}
         self._readout = readout
         super().__init__(**kwargs)
+        self.tracking = tracking
+
+    @property
+    def tracking(self) -> bool:
+        """Return whether slider tracking is enabled.
+
+        If tracking is enabled (the default), the slider emits the changed()
+        signal while the slider is being dragged. If tracking is disabled,
+        the slider emits the valueChanged() signal only when the user releases
+        the slider.
+        """
+        return self._widget._mgui_get_tracking()
+
+    @tracking.setter
+    def tracking(self, value: bool) -> None:
+        """Set whether slider tracking is enabled."""
+        self._widget._mgui_set_tracking(value)
 
     @property
     def options(self) -> dict:

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -18,6 +18,7 @@ from typing_extensions import Literal
 
 from magicgui.application import use_app
 from magicgui.types import FileDialogMode, PathLike
+from magicgui.widgets import _protocols
 from magicgui.widgets._bases.mixins import _OrientationMixin, _ReadOnlyMixin
 
 from ._bases import (
@@ -300,8 +301,15 @@ class LogSlider(TransformedRangedWidget):
         The base to use for the log, by default math.e.
     """
 
+    _widget: _protocols.SliderWidgetProtocol
+
     def __init__(
-        self, min: float = 1, max: float = 100, base: float = math.e, **kwargs
+        self,
+        min: float = 1,
+        max: float = 100,
+        base: float = math.e,
+        tracking=True,
+        **kwargs,
     ):
         for key in ("maximum", "minimum"):
             if key in kwargs:
@@ -325,6 +333,23 @@ class LogSlider(TransformedRangedWidget):
             widget_type=app.get_obj("Slider"),
             **kwargs,
         )
+        self.tracking = tracking
+
+    @property
+    def tracking(self) -> bool:
+        """Return whether slider tracking is enabled.
+
+        If tracking is enabled (the default), the slider emits the changed()
+        signal while the slider is being dragged. If tracking is disabled,
+        the slider emits the valueChanged() signal only when the user releases
+        the slider.
+        """
+        return self._widget._mgui_get_tracking()
+
+    @tracking.setter
+    def tracking(self, value: bool) -> None:
+        """Set whether slider tracking is enabled."""
+        self._widget._mgui_set_tracking(value)
 
     @property
     def _scale(self):

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -416,6 +416,12 @@ class SliderWidgetProtocol(RangedWidgetProtocol, SupportsOrientation, Protocol):
     def _mgui_set_readout_visibility(self, visible: bool) -> None:
         """Set visibility of readout widget."""
 
+    def _mgui_get_tracking(self) -> bool:
+        """If tracking is False, valueChanged is only emitted when released."""
+
+    def _mgui_set_tracking(self, tracking: bool) -> None:
+        """If tracking is False, valueChanged is only emitted when released."""
+
 
 # CONTAINER ----------------------------------------------------------------------
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -599,3 +599,10 @@ def test_radiobutton_reset_choices():
     assert len(wdg.native.findChildren(QRadioButton)) == 3
     wdg.reset_choices()
     assert len(wdg.native.findChildren(QRadioButton)) == 3
+
+
+def test_tracking():
+    slider = widgets.Slider(tracking=False)
+    assert slider.tracking is False
+    slider.tracking = True
+    assert slider.tracking


### PR DESCRIPTION
closes #https://github.com/napari/magicgui/issues/234

This adds a 'tracking' property to sliders, following the [naming set by Qt](https://doc.qt.io/qt-5/qabstractslider.html#tracking-prop):

> ### tracking : **bool**
> This property holds whether slider tracking is enabled
>
> ----------
>If tracking is enabled (the default), the slider emits the valueChanged() signal while the slider is being dragged. If tracking is disabled, the slider emits the valueChanged() signal only when the user releases the slider.


```py
from magicgui import magicgui


@magicgui(auto_call=True, input={"widget_type": "Slider", "tracking": False})
def slider(input=1):
    ...
```