### PR TITLE
Specify XDG_RUNTIME_DIR to avoid warnings showing up in the docs

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -43,6 +43,7 @@ jobs:
         run: jupyter-book build docs
         env:
           DISPLAY: ":99.0"
+          XDG_RUNTIME_DIR: "/tmp/runtime-runner"
 
       # Deploy the book's HTML to gh-pages branch
       - name: GitHub Pages action


### PR DESCRIPTION
I find 
![image](https://user-images.githubusercontent.com/90008/125192372-87795b00-e215-11eb-8994-b8e59181da0c.png)


Sprinkled in the docs 
https://napari.org/magicgui/usage/direct_api.html

I wonder if this will address it.

Can we monitor the temporary output?