### PR TITLE
Fix RangeWidget with implicit optional type

### DIFF
--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -41,7 +41,7 @@ class RangedWidget(ValueWidget):
         self.step = step
         self.min = min
         self.max = max
-        if val is not UNSET:
+        if val not in (UNSET, None):
             self.value = val
 
     @property

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -495,6 +495,18 @@ def test_range_widget_min():
         rw = widgets.RangeEdit(-100, 1000, 5, min=(0, 500, 5))
 
 
+def test_range_value_none():
+    """Test that arg: int = None defaults to 0"""
+
+    @magicgui
+    def f(x: int = None):
+        ...
+
+    assert f.x.value == 0
+    rw = widgets.SpinBox(value=None)
+    assert rw.value == 0
+
+
 def test_containers_show_nested_containers():
     """make sure showing a container shows a nested FunctionGui."""
 


### PR DESCRIPTION
This fixes failed initialization of a widget with an implied optional value, that now happens in 0.2.9:

```py
def func(x: int = None): ...
```

still not sure this is the best solution, but it at least brings us back to the 0.2.8 behavior where that would make a widget with a value of 0.
