### PR TITLE
Support partials and tz.curry

### DIFF
--- a/magicgui/signature.py
+++ b/magicgui/signature.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from magicgui.widgets import Container
     from magicgui.widgets._bases import Widget
 
+TZ_EMPTY = "__no__default__"
+
 
 def make_annotated(annotation=Any, options: dict = None) -> _AnnotatedAlias:
     """Merge a annotation and an options dict into an Annotated type.
@@ -134,7 +136,7 @@ class MagicParameter(inspect.Parameter):
         from magicgui.widgets._bases import create_widget
         from magicgui.widgets._bases.value_widget import UNSET
 
-        value = UNSET if self.default is self.empty else self.default
+        value = UNSET if self.default in (self.empty, TZ_EMPTY) else self.default
         annotation, options = split_annotated_type(self.annotation)
         widget = create_widget(
             name=self.name,

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -155,10 +155,16 @@ class FunctionGui(Container, Generic[_R]):
         # access attributes (like `__name__` that only function objects have).
         # Mypy doesn't seem catch this at this point:
         # https://github.com/python/mypy/issues/9934
-        self._callable_name = (
-            getattr(function, "__name__", None)
-            or f"{function.__module__}.{function.__class__}"
-        )
+        name = getattr(function, "__name__", None)
+        if not name:
+            try:
+                name = f"{function.__module__}.{function.__class__}"
+            except AttributeError:
+                # partials
+                f = getattr(function, "func", None)
+                name = getattr(f, "__name__", None) or str(function)
+        self._callable_name = name
+
         super().__init__(
             layout=layout,
             labels=labels,

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ testing =
     %(tqdm)s
     %(image)s
     matplotlib
+    toolz
 dev =
     ipython
     black

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -761,7 +761,7 @@ def test_curry():
     assert isinstance(wdg.y, widgets.LineEdit)
     assert not hasattr(wdg, "x")
     assert wdg("sdf") == "sdf1"
-    assert wdg._callable_name == "some_func"
+    assert wdg._callable_name == "some_func2"
 
     wdg2 = magicgui(some_func2(y="sdf"))
     assert len(wdg2) == 3  # keyword arguments don't change the partial signature

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -747,3 +747,25 @@ def test_partial():
     assert isinstance(wdg.y, widgets.LineEdit)
     assert wdg2.y.value == "sdf"
     assert wdg2(1) == "sdf1"
+
+
+def test_curry():
+    import toolz as tz
+
+    @tz.curry
+    def some_func2(x: int, y: str) -> str:
+        return y + str(x)
+
+    wdg = magicgui(some_func2(1))
+    assert len(wdg) == 2  # because of the call_button
+    assert isinstance(wdg.y, widgets.LineEdit)
+    assert not hasattr(wdg, "x")
+    assert wdg("sdf") == "sdf1"
+    assert wdg._callable_name == "some_func"
+
+    wdg2 = magicgui(some_func2(y="sdf"))
+    assert len(wdg2) == 3  # keyword arguments don't change the partial signature
+    assert isinstance(wdg2.x, widgets.SpinBox)
+    assert isinstance(wdg.y, widgets.LineEdit)
+    assert wdg2.y.value == "sdf"
+    assert wdg2(1) == "sdf1"

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -726,3 +726,24 @@ def test_update_on_call():
     assert test.a.value == 10
     assert test.y.value == "b"
     assert test.call_count == 1
+
+
+def test_partial():
+    from functools import partial
+
+    def some_func(x: int, y: str) -> str:
+        return y + str(x)
+
+    wdg = magicgui(partial(some_func, 1))
+    assert len(wdg) == 2  # because of the call_button
+    assert isinstance(wdg.y, widgets.LineEdit)
+    assert not hasattr(wdg, "x")
+    assert wdg("sdf") == "sdf1"
+    assert wdg._callable_name == "some_func"
+
+    wdg2 = magicgui(partial(some_func, y="sdf"))
+    assert len(wdg2) == 3  # keyword arguments don't change the partial signature
+    assert isinstance(wdg2.x, widgets.SpinBox)
+    assert isinstance(wdg.y, widgets.LineEdit)
+    assert wdg2.y.value == "sdf"
+    assert wdg2(1) == "sdf1"


### PR DESCRIPTION
This implements support for functions wrapped in functools.partial. closes #315

There is a slight "catch" ... which is really due to the way that partial handles signatures when providing positional vs keyword arguments.  Take this example

```py
    def some_func(x: int, y: str) -> str:
        return y + str(x)

    wdg1 = magicgui(partial(some_func, 1))  # first position
    wdg2 = magicgui(partial(some_func, y='hi'))  # second kwarg
```

wdg1 will look like this:

<img width="312" alt="Untitled" src="https://user-images.githubusercontent.com/1609449/141351347-f1d133f7-6512-4529-bede-dfe74cdb93a7.png">
and wdg2 will look like this


<img width="312" alt="Untitled2" src="https://user-images.githubusercontent.com/1609449/141351345-75577f51-228a-4610-ba6a-f1f2ce4ddb06.png">

they both _behave_ like the corresponding partials.  but wdg2 shows the widget for `y`, whereas `wdg` doesn't show `x`

To avoid that behavior automatically, we'd need to do a little special casing.  It's possible, but prefer to leave to another PR
