### PR TITLE
fix py3.10 test

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.platform }} (${{ matrix.python-version }})
+    name: ${{ matrix.platform }} (${{ matrix.python-version }}) ${{ matrix.backend }}
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -22,13 +22,13 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # until pyside2 is available for 3.10
-          - python: '3.10'
+          - python-version: '3.10'
             backend: pyqt
             platform: ubuntu-latest
-          - python: '3.10'
+          - python-version: '3.10'
             backend: pyqt
             platform: macos-latest
-          - python: '3.10'
+          - python-version: '3.10'
             backend: pyqt
             platform: windows-latest
     steps:

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -418,7 +418,6 @@ class MainWindow(Container):
         super().__init__(layout=layout)
         self._main_window = QtW.QMainWindow()
         self._main_window.setCentralWidget(self._qwidget)
-        self._main_menu = self._main_window.menuBar()
         self._menus: dict[str, QtW.QMenu] = {}
 
     def _mgui_get_visible(self):
@@ -434,7 +433,7 @@ class MainWindow(Container):
         self, menu_name: str, action_name: str, callback=None, shortcut=None
     ):
         menu = self._menus.setdefault(
-            menu_name, self._main_menu.addMenu(f"&{menu_name}")
+            menu_name, self._main_window.menuBar().addMenu(f"&{menu_name}")
         )
         action = QtW.QAction(action_name, self._main_window)
         if shortcut is not None:

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -159,12 +159,11 @@ class FunctionGui(Container, Generic[_R]):
         # https://github.com/python/mypy/issues/9934
         name = getattr(function, "__name__", None)
         if not name:
-            try:
-                name = f"{function.__module__}.{function.__class__}"
-            except AttributeError:
-                # partials
+            if hasattr(function, "func"):  # partials:
                 f = getattr(function, "func", None)
                 name = getattr(f, "__name__", None) or str(function)
+            else:
+                name = f"{function.__module__}.{function.__class__}"
         self._callable_name = name
 
         super().__init__(


### PR DESCRIPTION
there was an error in the workflow, and py310 wasn't getting tested correctly.

Looks like there was a bug in getting the name of a magicgui-decorated `functools.partial` in python 3.10.  this also fixes that.