### PR TITLE
Do not package tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,10 @@ install_requires =
     qtpy>=1.7.0
     typing_extensions
 
-
+[options.packages.find]
+exclude =
+    tests
+    
 [options.extras_require]
 pyside2 =
     pyside2>=5.13 ; python_version=='3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
 [options.packages.find]
 exclude =
     tests
-    
+
 [options.extras_require]
 pyside2 =
     pyside2>=5.13 ; python_version=='3.7'


### PR DESCRIPTION
This is clobbering other (accidentally mispackaged) files in other packages. [Example](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=451653&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=2360):

```
ClobberWarning: This transaction has incompatible packages due to a shared path.
  packages: conda-forge/noarch::magicgui-0.3.4-pyhd8ed1ab_0, conda-forge/noarch::starfile-0.4.11-pyhd8ed1ab_0
  path: 'lib/python3.10/site-packages/tests/__init__.py'

ClobberWarning: This transaction has incompatible packages due to a shared path.
  packages: conda-forge/noarch::magicgui-0.3.4-pyhd8ed1ab_0, conda-forge/noarch::starfile-0.4.11-pyhd8ed1ab_0
  path: 'lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.pyc'

Executing transaction: ...working... 
ClobberWarning: Conda was asked to clobber an existing path.
  source path: /opt/conda/pkgs/starfile-0.4.11-pyhd8ed1ab_0/site-packages/tests/__init__.py
  target path: /home/conda/staged-recipes/build_artifacts/napari-subboxer_1643751427783/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.10/site-packages/tests/__init__.py
```