### PR TITLE
Fix `_normalize_slot` private attr access, and fix annotation setter forward ref resolution

### DIFF
--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -53,7 +53,8 @@ class SignalInstance(psygnal.SignalInstance):
         result = super().connect(
             slot, check_nargs=check_nargs, check_types=check_types, unique=unique
         )
-        self._new_callback[self._normalize_slot(slot)] = is_new_style
+        norm = getattr(self, "_normalize_slot", psygnal._signal._normalize_slot)
+        self._new_callback[norm(slot)] = is_new_style
         return result
 
     def _run_emit_loop(self, args) -> None:

--- a/magicgui/widgets/_bases/widget.py
+++ b/magicgui/widgets/_bases/widget.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import inspect
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ForwardRef
+from typing import TYPE_CHECKING, Any
 
+from magicgui._type_wrapper import resolve_forward_refs
 from magicgui.application import use_app
 from magicgui.events import Signal
 from magicgui.widgets import _protocols
@@ -116,11 +117,7 @@ class Widget:
 
     @annotation.setter
     def annotation(self, value):
-        if isinstance(value, (str, ForwardRef)):
-            from magicgui._type_wrapper import TypeWrapper
-
-            value = TypeWrapper(value).resolve()
-        self._annotation = value
+        self._annotation = resolve_forward_refs(value)
 
     @property
     def param_kind(self) -> inspect._ParameterKind:

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -15,7 +15,6 @@ from typing import (
     Any,
     Callable,
     Deque,
-    ForwardRef,
     Generic,
     Iterable,
     Mapping,
@@ -23,6 +22,7 @@ from typing import (
     cast,
 )
 
+from magicgui._type_wrapper import resolve_forward_refs
 from magicgui.application import AppRef
 from magicgui.events import Signal
 from magicgui.signature import MagicSignature, magic_signature
@@ -246,12 +246,7 @@ class FunctionGui(Container, Generic[_R]):
 
     @return_annotation.setter
     def return_annotation(self, value):
-        if isinstance(value, (str, ForwardRef)):
-            from magicgui._type_wrapper import TypeWrapper
-
-            value = TypeWrapper(value).resolve()
-
-        self._return_annotation = value
+        self._return_annotation = resolve_forward_refs(value)
 
     @property
     def __signature__(self) -> MagicSignature:

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,6 +137,9 @@ ignore_errors = True
 [mypy-.examples,numpy.*,_pytest.*,packaging.*,importlib_metadata.*,docstring_parser.*,psygnal.*]
 ignore_errors = True
 
+[mypy-tomli.*]
+warn_unused_ignores = False
+
 
 [isort]
 profile = black

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -245,7 +245,7 @@ def test_visible_in_container():
     """Test that visibility depends on containers."""
     w1 = widgets.Label(value="hi", name="w1")
     w2 = widgets.Label(value="hi", name="w2")
-    w3 = widgets.Label(value="hi", name="w2", visible=False)
+    w3 = widgets.Label(value="hi", name="w3", visible=False)
     container = widgets.Container(widgets=[w2, w3])
     assert not w1.visible
     assert not w2.visible

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -371,18 +371,18 @@ def test_bound_callable_catches_recursion():
     (... rather than a recursion error)
     """
 
-    @magicgui(x={"bind": lambda x: x.value * 2})
-    def f(x: int = 5):
-        return x
-
     with pytest.raises(RuntimeError):
-        assert f() == 10
-    f.x.unbind()
-    assert f() == 5
+
+        @magicgui(x={"bind": lambda x: x.value * 2})
+        def f(x: int = 5):
+            return x
 
     # use `get_value` within the callback if you need to access widget.value
-    f.x.bind(lambda x: x.get_value() * 4)
-    assert f() == 20
+    @magicgui(x={"bind": lambda x: x.get_value() * 2})
+    def f2(x: int = 5):
+        return x
+
+    assert f2() == 10
 
 
 def test_reset_choice_recursion():


### PR DESCRIPTION
This fixes the `_normalize_slot` attribute error with psygnal 0.3.0.

this also fixes this trace observed by @jni:
```
~/projects/napari/napari/utils/_magicgui.py in <listcomp>(.0)
    325     if not viewer:
    326         return []
--> 327     return [x for x in viewer.layers if isinstance(x, gui.annotation)]
    328
    329

TypeError: isinstance() arg 2 must be a type or tuple of types
```