### PR TITLE
Use empty string as null value for FileEdit

### DIFF
--- a/magicgui/_type_wrapper.py
+++ b/magicgui/_type_wrapper.py
@@ -377,7 +377,7 @@ def resolve_annotation(
 
     if isinstance(annotation, str):
         if (3, 10) > sys.version_info >= (3, 9, 8) or sys.version_info >= (3, 10, 1):
-            annotation = ForwardRef(  # type: ignore
+            annotation = ForwardRef(
                 annotation, is_argument=False, is_class=True
             )
         else:

--- a/magicgui/_type_wrapper.py
+++ b/magicgui/_type_wrapper.py
@@ -377,9 +377,7 @@ def resolve_annotation(
 
     if isinstance(annotation, str):
         if (3, 10) > sys.version_info >= (3, 9, 8) or sys.version_info >= (3, 10, 1):
-            annotation = ForwardRef(
-                annotation, is_argument=False, is_class=True
-            )
+            annotation = ForwardRef(annotation, is_argument=False, is_class=True)
         else:
             annotation = ForwardRef(annotation, is_argument=False)
 

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -441,7 +441,10 @@ class FileEdit(Container):
         nullable=False,
         **kwargs,
     ):
-        self.line_edit = LineEdit(value=kwargs.pop("value", None))
+        value = kwargs.pop("value", None)
+        if value is None:
+            value = ''
+        self.line_edit = LineEdit(value=value)
         self.choose_btn = PushButton()
         self.mode = mode  # sets the button text too
         self.filter = filter
@@ -503,6 +506,8 @@ class FileEdit(Container):
     @value.setter
     def value(self, value: Sequence[PathLike] | PathLike):
         """Set current file path."""
+        if value is None and self._nullable:
+            value = ''
         if isinstance(value, (list, tuple)):
             value = ", ".join(os.fspath(p) for p in value)
         if not isinstance(value, (str, Path)):

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -504,7 +504,7 @@ class FileEdit(Container):
         return Path(text)
 
     @value.setter
-    def value(self, value: Sequence[PathLike] | PathLike):
+    def value(self, value: Sequence[PathLike] | PathLike | None):
         """Set current file path."""
         if value is None and self._nullable:
             value = ''


### PR DESCRIPTION
Fix for issue [raised on zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/MagicGUI.20FileEdit.20.60.2Evalue.60.20for.20uninitialized.20widgets), where even when setting `nullable=True`, `None` would be treated as an actual path, as well as being used as a default value. This replaces it with the empty string.

cc @VolkerH
