### PR TITLE
Fix pyqt conda isntall instruction

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -32,6 +32,6 @@ pip install magicgui[pyside2]
 
 or with conda:
 ```bash
-conda install -c conda-forge magicgui pyqt5
+conda install -c conda-forge magicgui pyqt
 ```
 ````


### PR DESCRIPTION
On `conda-forge` the package is `pyqt`, not `pyqt5`. Perhaps this should be changed to `pyqt=5` instead?