### PR TITLE
Make call_button public

### DIFF
--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -79,6 +79,7 @@ class FunctionGui(Container, Generic[_R]):
         If True, create an additional button that calls the original function when
         clicked.  If a ``str``, set the button text. by default False when
         auto_call is True, and True otherwise.
+        The button can be accessed from the ``.call_button`` property.
     layout : str, optional
         The type of layout to use. Must be one of {'horizontal', 'vertical'}.
         by default "horizontal".
@@ -227,6 +228,11 @@ class FunctionGui(Container, Generic[_R]):
             self._dump()
         if self._auto_call:
             self()
+
+    @property
+    def call_button(self) -> PushButton | None:
+        """Return the call button."""
+        return self._call_button
 
     @property
     def call_count(self) -> int:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -17,14 +17,14 @@ def test_magic_factory():
     # factories make widgets that are FunctionGui instances
     widget1 = factory()
     assert isinstance(widget1, FunctionGui)
-    assert widget1._call_button
+    assert widget1.call_button
 
     # You can call them repeatedly, and even override the initial kwargs
     # given to magic_factory (just like with functools.partial)
     widget2 = factory(call_button=False, x={"widget_type": "Slider"})
     assert widget1 is not widget2
     assert isinstance(widget2, FunctionGui)
-    assert not widget2._call_button
+    assert not widget2.call_button
     assert isinstance(widget2.x, Slider)
 
     # the widget, (like all FunctionGuis) is still callable and accepts args

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -58,9 +58,9 @@ def test_magicgui(magic_func):
 
 
 def test_default_call_button_behavior(magic_func_defaults, magic_func_autocall):
-    assert magic_func_defaults._call_button is not None
+    assert magic_func_defaults.call_button is not None
 
-    assert magic_func_autocall._call_button is None
+    assert magic_func_autocall.call_button is None
     prior_autocall_count = magic_func_autocall.call_count
     magic_func_autocall.a.value = "hello"
     magic_func_autocall.b.value = 7
@@ -131,8 +131,8 @@ def test_call_button():
     def func(a: int, b: int = 3, c=7.1):
         assert a == 7
 
-    assert hasattr(func, "_call_button")
-    assert isinstance(func._call_button, widgets.PushButton)
+    assert hasattr(func, "call_button")
+    assert isinstance(func.call_button, widgets.PushButton)
     func.a.value = 7
 
 
@@ -499,7 +499,7 @@ def test_function_binding():
     a = MyObject("a")
     b = MyObject("b")
 
-    assert a.method._call_button.text == "callme"  # type: ignore
+    assert a.method.call_button.text == "callme"  # type: ignore
     assert a.method.sigma.max == 365
     assert a.method() == ("a", 1)
     assert b.method(sigma=4) == ("b", 4)


### PR DESCRIPTION
See https://github.com/napari/magicgui/issues/381#issuecomment-1060550957 and associated discussion. This allows public access to the button automatically created by `magicgui` so it can be modified after creating the GUI.