### PR TITLE
Fix insertion of Container widget

### DIFF
--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -174,9 +174,9 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
                 _widget = _LabeledWidget(widget)
                 widget.label_changed.connect(self._unify_label_widths)
 
-        self._list.insert(key, widget)
         if key < 0:
-            key += len(self) - 1
+            key += len(self)
+        self._list.insert(key, widget)
         # NOTE: if someone has manually mucked around with self.native.layout()
         # it's possible that indices will be off.
         self._widget._mgui_insert_widget(key, _widget)

--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -176,7 +176,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
 
         self._list.insert(key, widget)
         if key < 0:
-            key += len(self)
+            key += len(self) - 1
         # NOTE: if someone has manually mucked around with self.native.layout()
         # it's possible that indices will be off.
         self._widget._mgui_insert_widget(key, _widget)


### PR DESCRIPTION
Fixes #393.
Looks like the `key` should be incremented *before* insertion.

How should I add a test for this?
It seems the widget order cannot be tested outside Qt.