### PR TITLE
Fix bug in creation of RangeEdit using create_widget

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: pyupgrade
         args: ["--py37-plus", "--keep-runtime-typing"]
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -553,7 +553,7 @@ class RangeEdit(Container):
         **kwargs,
     ):
         value = kwargs.pop("value", None)
-        if value is not None:
+        if value is not None and value is not UNSET:
             if not all(hasattr(value, x) for x in ("start", "stop", "step")):
                 raise TypeError(f"Invalid value type for {type(self)}: {type(value)}")
             start, stop, step = value.start, value.stop, value.step
@@ -565,6 +565,7 @@ class RangeEdit(Container):
         kwargs["widgets"] = [self.start, self.stop, self.step]
         kwargs.setdefault("layout", "horizontal")
         kwargs.setdefault("labels", True)
+        kwargs.pop("nullable", None)
         super().__init__(**kwargs)
 
     @classmethod

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,3 +1,4 @@
+import datetime
 import inspect
 from enum import Enum
 from pathlib import Path
@@ -45,6 +46,26 @@ def test_create_widget(kwargs, expect_type):
     """Test that various values get turned into widgets."""
     wdg = widgets.create_widget(**kwargs)
     assert isinstance(wdg, expect_type)
+    wdg.close()
+
+
+expectations_annotation = (
+    (int, widgets.SpinBox),
+    (float, widgets.FloatSpinBox),
+    (range, widgets.RangeEdit),
+    (str, widgets.LineEdit),
+    (bool, widgets.CheckBox),
+    (slice, widgets.SliceEdit),
+    (datetime.date, widgets.DateEdit),
+    (datetime.time, widgets.TimeEdit),
+    (datetime.datetime, widgets.DateTimeEdit),
+)
+
+
+@pytest.mark.parametrize("annotation, expected_type", expectations_annotation)
+def test_create_widget_annotation(annotation, expected_type):
+    wdg = widgets.create_widget(annotation=annotation)
+    assert isinstance(wdg, expected_type)
     wdg.close()
 
 


### PR DESCRIPTION
When run this code 

```python
from magicgui.widgets import create_widget

w = create_widget(annotation=range)
```
it ends with error:
```
Traceback (most recent call last):
  File "/home/czaki/Projekty/neutrofile/Tutorial/sample_magicgui.py", line 3, in <module>
    w = create_widget(annotation=range)
  File "/home/czaki/.pyenv/versions/3.8.3/envs/neutrofile/lib/python3.8/site-packages/magicgui/widgets/_bases/create_widget.py", line 96, in create_widget
    widget = wdg_class(**kwargs)
  File "/home/czaki/.pyenv/versions/3.8.3/envs/neutrofile/lib/python3.8/site-packages/magicgui/widgets/_concrete.py", line 558, in __init__
    raise TypeError(f"Invalid value type for {type(self)}: {type(value)}")
TypeError: Invalid value type for <class 'magicgui.widgets.RangeEdit'>: <class 'magicgui.widgets._bases.value_widget._Unset'>
```

When fixing this error by checking if `value` is `None` or `UNSET` then also happens problem with an unexpected `nullable` field.
The second error I fix  by `pop` the `nullable` from kwargs. But I'm not sure if it is the correct solution.  