### PR TITLE
Fix bug with small default range in SpinBox

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -452,6 +452,9 @@ class SpinBox(QBaseRangedWidget):
     def _mgui_set_value(self, value) -> None:
         super()._mgui_set_value(int(value))
 
+    def _pre_set_hook(self, value):
+        return int(value)
+
 
 class FloatSpinBox(QBaseRangedWidget):
     def __init__(self):
@@ -499,6 +502,9 @@ class _Slider(QBaseRangedWidget, _protocols.SupportsOrientation):
         # Progressbar also uses this base, but doesn't have tracking
         if hasattr(self._qwidget, "setTracking"):
             self._qwidget.setTracking(value)
+
+    def _pre_set_hook(self, value):
+        return int(value)
 
 
 class Slider(_Slider):

--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -45,7 +45,7 @@ class RangedWidget(ValueWidget):
         val = kwargs.pop("value", UNSET)
         super().__init__(**kwargs)
 
-        tmp_val = val if val not in (UNSET, None) else 1
+        tmp_val = float(val if val not in (UNSET, None) else 1)
 
         self.step = step
         self.min = min if min is not UNSET else py_min(0, tmp_val)

--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -1,26 +1,24 @@
+import builtins
 from abc import ABC, abstractmethod
 from math import ceil, log10
-from typing import Tuple
+from typing import Tuple, Union, cast
 from warnings import warn
 
 from magicgui.widgets import _protocols
 
-from .value_widget import UNSET, ValueWidget
-
-py_min = min
-py_max = max
-# Workaround for names that are used in RangeWidget constructor
+from .value_widget import UNSET, ValueWidget, _Unset
 
 
 class RangedWidget(ValueWidget):
-    """Widget with a contstrained value. Wraps RangedWidgetProtocol.
+    """Widget with a constrained value. Wraps RangedWidgetProtocol.
 
     Parameters
     ----------
     min : float, optional
-        The minimum allowable value, by default 0
+        The minimum allowable value, by default 0 (or `value` if `value` is less than 0)
     max : float, optional
-        The maximum allowable value, by default 1000
+        The maximum allowable value, by default 1000 (or `value` if `value` is greater
+        than 1000)
     step : float, optional
         The step size for incrementing the value, by default 1
     """
@@ -28,8 +26,12 @@ class RangedWidget(ValueWidget):
     _widget: _protocols.RangedWidgetProtocol
 
     def __init__(
-        self, min: float = UNSET, max: float = UNSET, step: float = 1, **kwargs
-    ):
+        self,
+        min: Union[float, _Unset] = UNSET,
+        max: Union[float, _Unset] = UNSET,
+        step: float = 1,
+        **kwargs,
+    ):  # sourcery skip: avoid-builtin-shadow
         for key in ("maximum", "minimum"):
             if key in kwargs:
                 warn(
@@ -48,11 +50,13 @@ class RangedWidget(ValueWidget):
         tmp_val = float(val if val not in (UNSET, None) else 1)
 
         self.step = step
-        self.min = min if min is not UNSET else py_min(0, tmp_val)
-        self.max = (
-            max
+        self.min: float = (
+            cast(float, min) if min is not UNSET else builtins.min(0, tmp_val)
+        )
+        self.max: float = (
+            cast(float, max)
             if max is not UNSET
-            else py_max(1000, 10 ** ceil(log10(py_max(1, tmp_val + 1)))) - 1
+            else builtins.max(1000, 10 ** ceil(log10(builtins.max(1, tmp_val + 1)))) - 1
         )
         if val not in (UNSET, None):
             self.value = val

--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from math import ceil,log10
+from math import ceil, log10
 from typing import Tuple
 from warnings import warn
 
@@ -10,6 +10,7 @@ from .value_widget import UNSET, ValueWidget
 py_min = min
 py_max = max
 # Workaround for names that are used in RangeWidget constructor
+
 
 class RangedWidget(ValueWidget):
     """Widget with a contstrained value. Wraps RangedWidgetProtocol.
@@ -26,7 +27,9 @@ class RangedWidget(ValueWidget):
 
     _widget: _protocols.RangedWidgetProtocol
 
-    def __init__(self, min: float = UNSET, max: float = UNSET, step: float = 1, **kwargs):
+    def __init__(
+        self, min: float = UNSET, max: float = UNSET, step: float = 1, **kwargs
+    ):
         for key in ("maximum", "minimum"):
             if key in kwargs:
                 warn(
@@ -46,7 +49,11 @@ class RangedWidget(ValueWidget):
 
         self.step = step
         self.min = min if min is not UNSET else py_min(0, tmp_val)
-        self.max = max if max is not UNSET else py_max(1000, 10**ceil(log10(py_max(1, tmp_val+1))))-1
+        self.max = (
+            max
+            if max is not UNSET
+            else py_max(1000, 10 ** ceil(log10(py_max(1, tmp_val + 1)))) - 1
+        )
         if val not in (UNSET, None):
             self.value = val
 

--- a/magicgui/widgets/_bases/ranged_widget.py
+++ b/magicgui/widgets/_bases/ranged_widget.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from math import ceil,log10
 from typing import Tuple
 from warnings import warn
 
@@ -6,6 +7,9 @@ from magicgui.widgets import _protocols
 
 from .value_widget import UNSET, ValueWidget
 
+py_min = min
+py_max = max
+# Workaround for names that are used in RangeWidget constructor
 
 class RangedWidget(ValueWidget):
     """Widget with a contstrained value. Wraps RangedWidgetProtocol.
@@ -22,7 +26,7 @@ class RangedWidget(ValueWidget):
 
     _widget: _protocols.RangedWidgetProtocol
 
-    def __init__(self, min: float = 0, max: float = 1000, step: float = 1, **kwargs):
+    def __init__(self, min: float = UNSET, max: float = UNSET, step: float = 1, **kwargs):
         for key in ("maximum", "minimum"):
             if key in kwargs:
                 warn(
@@ -38,9 +42,11 @@ class RangedWidget(ValueWidget):
         val = kwargs.pop("value", UNSET)
         super().__init__(**kwargs)
 
+        tmp_val = val if val not in (UNSET, None) else 1
+
         self.step = step
-        self.min = min
-        self.max = max
+        self.min = min if min is not UNSET else py_min(0, tmp_val)
+        self.max = max if max is not UNSET else py_max(1000, 10**ceil(log10(py_max(1, tmp_val+1))))-1
         if val not in (UNSET, None):
             self.value = val
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -157,7 +157,7 @@ def test_basic_widget_attributes():
 
     assert repr(widget) == "SpinBox(value=1, annotation=None, name='my_name')"
     assert widget.options == {
-        "max": 1000,
+        "max": 999,
         "min": 0,
         "step": 1,
         "enabled": False,

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -536,16 +536,21 @@ def test_range_value_none():
     rw = widgets.SpinBox(value=None)
     assert rw.value == 0
 
-@pytest.mark.parametrize("value,maksimum", [(10, 999), (None, 999), (1000, 9999), (1500, 9999)])
+
+@pytest.mark.parametrize(
+    "value,maksimum", [(10, 999), (None, 999), (1000, 9999), (1500, 9999)]
+)
 def test_range_big_value(value, maksimum):
     rw = widgets.SpinBox(value=value)
     rw.value == value
     rw.max = maksimum
 
+
 def test_range_negative_value():
     rw = widgets.SpinBox(value=-10)
     rw.value == -10
     rw.min == -10
+
 
 def test_exception_range_out_of_range():
     with pytest.raises(ValueError):
@@ -553,6 +558,7 @@ def test_exception_range_out_of_range():
 
     with pytest.raises(ValueError):
         widgets.SpinBox(value=-10, min=0)
+
 
 def test_containers_show_nested_containers():
     """make sure showing a container shows a nested FunctionGui."""

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -536,6 +536,23 @@ def test_range_value_none():
     rw = widgets.SpinBox(value=None)
     assert rw.value == 0
 
+@pytest.mark.parametrize("value,maksimum", [(10, 999), (None, 999), (1000, 9999), (1500, 9999)])
+def test_range_big_value(value, maksimum):
+    rw = widgets.SpinBox(value=value)
+    rw.value == value
+    rw.max = maksimum
+
+def test_range_negative_value():
+    rw = widgets.SpinBox(value=-10)
+    rw.value == -10
+    rw.min == -10
+
+def test_exception_range_out_of_range():
+    with pytest.raises(ValueError):
+        widgets.SpinBox(value=10000, max=1000)
+
+    with pytest.raises(ValueError):
+        widgets.SpinBox(value=-10, min=0)
 
 def test_containers_show_nested_containers():
     """make sure showing a container shows a nested FunctionGui."""


### PR DESCRIPTION
The default range in SpinBox is 0, 1000 which is really small. Try to create a widget with a value outside the default range causing the Exception. This PR adjusts the min-max range if the initial value is outside it. 