### PR TITLE
Fix typesafety tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -134,7 +134,7 @@ ignore_missing_imports = True
 [mypy-.examples/,magicgui._mpl_image.*]
 ignore_errors = True
 
-[mypy-.examples,numpy.*,_pytest.*,packaging.*,importlib_metadata.*,docstring_parser.*,psygnal.*]
+[mypy-.examples,numpy.*,_pytest.*,packaging.*,pyparsing.*,importlib_metadata.*,docstring_parser.*,psygnal.*]
 ignore_errors = True
 
 [mypy-tomli.*]


### PR DESCRIPTION
currently broken on py3.7 because of an upstream typing issue