### PR TITLE
Bug fix of type check in ListEdit

### DIFF
--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -654,8 +654,9 @@ class ListEdit(Container):
         self.margins = (0, 0, 0, 0)
 
         if not isinstance(value, _Unset):
+            # check type consistency
             types = {type(a) for a in value}
-            if len(types) == 1:
+            if len(types) <= 1:
                 if self._args_type is None:
                     self._args_type = types.pop()
             else:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -862,6 +862,18 @@ def test_list_edit():
     assert f3.x[0].max == 10
     assert f3.x[0].step == 5
 
+    @magicgui
+    def f4(x: List[int] = ()):  # type: ignore
+        pass
+
+    assert type(f4.x) is widgets.ListEdit
+    assert f4.x.annotation == List[int]
+    assert f4.x._args_type is int
+    assert f4.x.value == []
+    f4.x.btn_plus.changed()
+    assert type(f4.x[0]) is widgets.SpinBox
+    assert f4.x.value == [0]
+
 
 def test_tuple_edit():
     """Test TupleEdit."""


### PR DESCRIPTION
This PR fixes a bug in `ListEdit`.
I found `ListEdit` could not deal with type annotation of `list[...]` with an empty list as the default value.

```python
@magicgui
def f(x: list[int]): ...  # OK

@magicgui
def f(x: list[int] = []): ...  # Error!

```