### PR TITLE
Block event emits during choices batch update

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -693,6 +693,7 @@ class ComboBox(QBaseValueWidget, _protocols.CategoricalWidgetProtocol):
             self._qwidget.clear()
             return
 
+        self._qwidget.blockSignals(True)
         choice_names = [x[0] for x in choices_]
         # remove choices that no longer exist
         for i in reversed(range(self._qwidget.count())):
@@ -709,6 +710,8 @@ class ComboBox(QBaseValueWidget, _protocols.CategoricalWidgetProtocol):
             first = choice_names[0]
             self._qwidget.setCurrentIndex(self._qwidget.findText(first))
             self._qwidget.removeItem(self._qwidget.findText(current))
+        self._qwidget.blockSignals(False)
+        self._emit_data(self._qwidget.currentIndex())
 
     def _mgui_del_choice(self, choice_name: str) -> None:
         """Delete choice_name."""

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -771,9 +771,11 @@ class Select(QBaseValueWidget, _protocols.CategoricalWidgetProtocol):
     def _mgui_set_value(self, value) -> None:
         if not isinstance(value, (list, tuple)):
             value = [value]
-        for i in range(self._qwidget.count()):
-            item = self._qwidget.item(i)
-            item.setSelected(item.data(Qt.ItemDataRole.UserRole) in value)
+        with _signals_blocked(self._qwidget):
+            for i in range(self._qwidget.count()):
+                item = self._qwidget.item(i)
+                item.setSelected(item.data(Qt.ItemDataRole.UserRole) in value)
+        self._emit_data()
 
     def _mgui_set_choice(self, choice_name: str, data: Any) -> None:
         """Set data for ``choice_name``."""
@@ -795,14 +797,16 @@ class Select(QBaseValueWidget, _protocols.CategoricalWidgetProtocol):
             self._qwidget.clear()
             return
 
-        choice_names = [x[0] for x in choices_]
-        # remove choices that no longer exist
-        for i in reversed(range(self._qwidget.count())):
-            if self._qwidget.item(i).text() not in choice_names:
-                self._qwidget.takeItem(i)
-        # update choices
-        for name, data in choices_:
-            self._mgui_set_choice(name, data)
+        with _signals_blocked(self._qwidget):
+            choice_names = [x[0] for x in choices_]
+            # remove choices that no longer exist
+            for i in reversed(range(self._qwidget.count())):
+                if self._qwidget.item(i).text() not in choice_names:
+                    self._qwidget.takeItem(i)
+            # update choices
+            for name, data in choices_:
+                self._mgui_set_choice(name, data)
+        self._emit_data()
 
     def _mgui_del_choice(self, choice_name: str) -> None:
         """Delete choice_name."""

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -1120,9 +1120,8 @@ class Table(QBaseWidget, _protocols.TableWidgetProtocol):
         return self._qwidget._read_only
 
     def _update_item_data_with_text(self, item: QtW.QTableWidgetItem):
-        self._qwidget.blockSignals(True)
-        item.setData(self._DATA_ROLE, _maybefloat(item.text()))
-        self._qwidget.blockSignals(False)
+        with _signals_blocked(self._qwidget):
+            item.setData(self._DATA_ROLE, _maybefloat(item.text()))
 
     def _mgui_set_row_count(self, nrows: int) -> None:
         """Set the number of rows in the table. (Create/delete as needed)."""

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -681,19 +681,54 @@ def test_categorical_widgets(Cls):
     assert wdg.choices == (1, 2)
 
 
-@pytest.mark.parametrize("Cls", [widgets.ComboBox])
-def test_reset_choices_emits_once(Cls):
-    data = {"index": ["c1", "c2", "c3"]}
+@pytest.mark.parametrize(
+    "Cls,value", [(widgets.ComboBox, "c3"), (widgets.Select, ["c2", "c3"])]
+)
+def test_reset_choices_emits_once(Cls, value):
+    data = ["c1", "c2", "c3"]
     wdg = Cls(
-        value="c3",
-        choices=lambda w: data["index"],
+        value=value,
+        choices=lambda w: data,
     )
 
     mock = MagicMock()
     wdg.changed.connect(mock)
     mock.assert_not_called()
-    data["index"] = ["d2", "d4"]
+    data = ["d2", "d4"]
     wdg.reset_choices()
+    mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "Cls,value1,value2",
+    [(widgets.ComboBox, "c4", "c1"), (widgets.Select, ["c3", "c4"], ["c1", "c2"])],
+)
+def test_set_value_emits_once(Cls, value1, value2):
+    wdg = Cls(
+        value=value1,
+        choices=["c1", "c2", "c3", "c4"],
+    )
+
+    mock = MagicMock()
+    wdg.changed.connect(mock)
+    mock.assert_not_called()
+    wdg.value = value2
+    mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "Cls,value", [(widgets.ComboBox, "c3"), (widgets.Select, ["c3", "c4"])]
+)
+def test_set_choices_emits_once(Cls, value):
+    wdg = Cls(
+        value=value,
+        choices=["c1", "c2", "c3", "c4"],
+    )
+
+    mock = MagicMock()
+    wdg.changed.connect(mock)
+    mock.assert_not_called()
+    wdg.choices = ["d2", "d4", "d5"]
     mock.assert_called_once()
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -681,6 +681,22 @@ def test_categorical_widgets(Cls):
     assert wdg.choices == (1, 2)
 
 
+@pytest.mark.parametrize("Cls", [widgets.ComboBox])
+def test_reset_choices_emits_once(Cls):
+    data = {"index": ["c1", "c2", "c3"]}
+    wdg = Cls(
+        value="c3",
+        choices=lambda w: data["index"],
+    )
+
+    mock = MagicMock()
+    wdg.changed.connect(mock)
+    mock.assert_not_called()
+    data["index"] = ["d2", "d4"]
+    wdg.reset_choices()
+    mock.assert_called_once()
+
+
 class MyEnum(Enum):
     A = "a"
     B = "b"


### PR DESCRIPTION
This PR fixes https://github.com/napari/magicgui/issues/406.

Every `_qwidget.removeItem(i)` can potentially change the `currentIndex` and trigger an event.
By blocking events during the remove/add operations, we turn this into a batch change and trigger a single event with the final `currentIndex` afterwards.