### PR TITLE
Return empty tuple for no selected files

### DIFF
--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -510,13 +510,15 @@ class FileEdit(Container):
         """Set current file path."""
         if value is None and self._nullable:
             value = ""
-        if isinstance(value, (list, tuple)):
-            value = ", ".join(os.fspath(p) for p in value)
-        if not isinstance(value, (str, Path)):
+        elif isinstance(value, (list, tuple)):
+            value = ", ".join(os.fspath(Path(p).expanduser().absolute()) for p in value)
+        elif isinstance(value, (str, Path)):
+            value = os.fspath(Path(value).expanduser().absolute())
+        else:
             raise TypeError(
                 f"value must be a string, or list/tuple of strings, got {type(value)}"
             )
-        self.line_edit.value = os.fspath(Path(value).expanduser().absolute())
+        self.line_edit.value = value
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -502,7 +502,7 @@ class FileEdit(Container):
         if self._nullable and not text:
             return None
         if self.mode is FileDialogMode.EXISTING_FILES:
-            return tuple(Path(p) for p in text.split(", "))
+            return tuple(Path(p) for p in text.split(", ")) if text else tuple()
         return Path(text)
 
     @value.setter

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -502,7 +502,7 @@ class FileEdit(Container):
         if self._nullable and not text:
             return None
         if self.mode is FileDialogMode.EXISTING_FILES:
-            return tuple(Path(p) for p in text.split(", ")) if text else tuple()
+            return tuple(Path(p) for p in text.split(", ") if p.strip())
         return Path(text)
 
     @value.setter

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from tests import MyInt
 
-from magicgui import magicgui, use_app, widgets
+from magicgui import magicgui, types, use_app, widgets
 from magicgui.widgets._bases import ValueWidget
 
 
@@ -627,6 +627,37 @@ def test_file_dialog_button_events():
         fe.choose_btn.changed.emit("value")
     mock.assert_not_called()
     assert fe.value == Path("hi")
+
+
+def test_file_edit_values():
+    cwd = Path(".").absolute()
+
+    fe = widgets.FileEdit(mode=types.FileDialogMode.EXISTING_FILE)
+    assert isinstance(fe.value, Path)
+
+    fe.value = "hi"
+    assert fe.value == cwd / "hi"
+
+    fe = widgets.FileEdit(mode=types.FileDialogMode.EXISTING_FILE, nullable=True)
+    assert fe.value is None
+
+    fe.value = "hi"
+    assert fe.value == cwd / "hi"
+
+    fe.value = None
+    assert fe.value is None # FIXME: Fails because empty string is expanded to absolute path
+
+    fe = widgets.FileEdit(mode=types.FileDialogMode.EXISTING_FILES)
+    assert fe.value == tuple()
+
+    fe.value = "hi"
+    assert fe.value == (cwd / "hi",)
+
+    fe.value = ("hi", "world")
+    assert fe.value == (cwd / "hi", cwd / "world") # FIXME: Fails because only first path is expanded
+
+    fe.value = tuple()
+    assert fe.value == tuple() # FIXME: Fails because empty string is expanded to absolute path
 
 
 def test_null_events():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -635,29 +635,29 @@ def test_file_edit_values():
     fe = widgets.FileEdit(mode=types.FileDialogMode.EXISTING_FILE)
     assert isinstance(fe.value, Path)
 
-    fe.value = "hi"
+    fe.value = Path("hi")
     assert fe.value == cwd / "hi"
 
     fe = widgets.FileEdit(mode=types.FileDialogMode.EXISTING_FILE, nullable=True)
     assert fe.value is None
 
-    fe.value = "hi"
+    fe.value = Path("hi")
     assert fe.value == cwd / "hi"
 
     fe.value = None
-    assert fe.value is None # FIXME: Fails because empty string is expanded to absolute path
+    assert fe.value is None
 
     fe = widgets.FileEdit(mode=types.FileDialogMode.EXISTING_FILES)
     assert fe.value == tuple()
 
-    fe.value = "hi"
+    fe.value = Path("hi")
     assert fe.value == (cwd / "hi",)
 
-    fe.value = ("hi", "world")
-    assert fe.value == (cwd / "hi", cwd / "world") # FIXME: Fails because only first path is expanded
+    fe.value = (Path("hi"), Path("world"))
+    assert fe.value == (cwd / "hi", cwd / "world")
 
     fe.value = tuple()
-    assert fe.value == tuple() # FIXME: Fails because empty string is expanded to absolute path
+    assert fe.value == tuple()
 
 
 def test_null_events():


### PR DESCRIPTION
This change makes the FileEdit in EXISTING_FILES mode return an empty tuple if no files are selected.

The ability to detect "no selected file" is important to prevent parsing invalid/non existing files. The FileEdit has three possibilities, either it always has a Path value, or it is nullable and the neutral value should be None, or it is in multiple file selection mode and according to the signature the neutral value should be a tuple of zero length.

However, since `"".split(some_delimiter)` always gives `[""]` instead of `[]`, it currently returns a tuple with an empty path `Path(".")` which equals the home directory and is rather impractical to distinguish from an intentionally selected path.