### PR TITLE
Bump jupyter-book to 0.12.x

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book==0.11.3
+jupyter-book==0.12.3
 sphinx_material==0.0.34
 jupytext==1.10.3
 numpy


### PR DESCRIPTION
Fixes https://github.com/napari/magicgui/issues/426

The issue there was that `jupyter-book 0.11` specifies sphinx<4, which is not compatable with a certain version of Jinja2 which has to be manually pinned (see https://github.com/sphinx-doc/sphinx/issues/10291). Instead, bumping `jupyter-book` to 0.12 should allow useage of sphinx 4, avoiding the above error. As far as I can tell from the jupter-book changelog there's no breaking changes in this update. 