### PR TITLE
Expose QScrollArea as native widget

### DIFF
--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -84,6 +84,9 @@ class QBaseWidget(_protocols.WidgetProtocol):
     def _mgui_get_native_widget(self) -> QtW.QWidget:
         return self._qwidget
 
+    def _mgui_get_root_native_widget(self) -> QtW.QWidget:
+        return self._qwidget
+
     def _mgui_get_width(self) -> int:
         """Return the current width of the widget."""
         return self._qwidget.width()
@@ -428,7 +431,11 @@ class Container(
     def _is_scrollable(self) -> bool:
         return isinstance(self._qwidget, QtW.QScrollArea)
 
+    def _mgui_get_root_native_widget(self):
+        return self._qwidget
+
     def _mgui_get_native_widget(self):
+        # Return widget with the layout set
         return self._qwidget.widget() if self._is_scrollable else self._qwidget
 
     def _mgui_get_visible(self):

--- a/magicgui/widgets/_bases/widget.py
+++ b/magicgui/widgets/_bases/widget.py
@@ -149,8 +149,25 @@ class Widget:
 
     @property
     def native(self):
-        """Return native backend widget."""
+        """
+        Return native backend widget.
+
+        Note this is the widget that contains the layout, and not any
+        parent widgets of this (e.g. a parent widget that is used to
+        enable scroll bars)
+        """
         return self._widget._mgui_get_native_widget()
+
+    @property
+    def root_native_widget(self):
+        """
+        Return the root native backend widget.
+
+        This can be different from the ``.native`` widget if the layout
+        is a child of some other widget, e.g. a widget used to enable
+        scroll bars.
+        """
+        return self._widget._mgui_get_root_native_widget()
 
     @property
     def enabled(self) -> bool:

--- a/magicgui/widgets/_protocols.py
+++ b/magicgui/widgets/_protocols.py
@@ -82,6 +82,10 @@ class WidgetProtocol(Protocol):
         raise NotImplementedError()
 
     @abstractmethod
+    def _mgui_get_root_native_widget(self) -> Any:
+        raise NotImplementedError()
+
+    @abstractmethod
     def _mgui_bind_parent_change_callback(
         self, callback: Callable[[Any], None]
     ) -> None:

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -812,9 +812,13 @@ def test_scrollable():
     def test_scrollable(a: int = 1, y: str = "a"):
         ...
 
+    assert test_scrollable.native is not test_scrollable.root_native_widget
+    assert not isinstance(test_scrollable.native, QScrollArea)
+    assert isinstance(test_scrollable.root_native_widget, QScrollArea)
+
     @magicgui(scrollable=False)
     def test_nonscrollable(a: int = 1, y: str = "a"):
         ...
 
-    assert isinstance(test_scrollable.native.parent().parent(), QScrollArea)
-    assert not test_nonscrollable.native.parent()
+    assert test_nonscrollable.native is test_nonscrollable.root_native_widget
+    assert not isinstance(test_nonscrollable.native, QScrollArea)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -82,6 +82,7 @@ class MyBadWidget:
     def _mgui_get_parent(self): ... # noqa
     def _mgui_set_parent(self, widget): ... # noqa
     def _mgui_get_native_widget(self): return MagicMock()  # noqa
+    def _mgui_get_root_native_widget(self): ... # noqa
     def _mgui_bind_parent_change_callback(self, callback): ... # noqa
     def _mgui_render(self): ... # noqa
     def _mgui_get_width(self): ... # noqa


### PR DESCRIPTION
Fixes https://github.com/napari/magicgui/issues/431 - this allows an external user to access the `QScrollArea` by returning it as the native widget. I think this is a sensible thing to do anyway, and it fixes a bug with the scroll bars not showing up when a widget is consumed by `napari`.