### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/examples/napari/napari_img_math.md
+++ b/docs/examples/napari/napari_img_math.md
@@ -7,7 +7,7 @@ we're going to build this simple image arithmetic widget with a few additional
 lines of code.
 
 For napari-specific magicgui documentation, see the
-[napari docs](https://napari.org/guides/stable/magicgui.html)
+[napari docs](https://napari.org/guides/magicgui.html)
 
 ```{image} ../../images/imagemath.gif
 :width: 80%
@@ -91,7 +91,7 @@ arithmetic.
 ### the function
 
 Our function takes two `numpy` arrays (in this case, from [Image
-layers](https://napari.org/tutorials/fundamentals/image)), and some mathematical
+layers](https://napari.org/howtos/layers/image.html)), and some mathematical
 operation (we'll restrict the options using an {class}`~enum.Enum`).  When
 called, our function calls the selected operation on the data.
 
@@ -109,7 +109,7 @@ types (using {func}`magicgui.type_map.register_type`). `napari` [provides
 support for
 `magicgui`](https://github.com/napari/napari/blob/main/napari/utils/_magicgui.py)
 by registering a dropdown menu whenever a function parameter is annotated as one
-of the basic napari [`Layer` types](https://napari.org/tutorials/), or, in this
+of the basic napari [`Layer` types](https://napari.org/howtos/layers/index.html), or, in this
 case, `ImageData` indicates we just the `data` attribute of the layer.
 Furthermore, it recognizes when a function has a
 {class}`~napari.layers.base.base.Layer` or `LayerData` return type annotation,

--- a/docs/examples/napari/napari_parameter_sweep.md
+++ b/docs/examples/napari/napari_parameter_sweep.md
@@ -7,7 +7,7 @@ we demonstrate how to build a interactive widget that lets you immediately see
 the effect of changing one of the parameters of your function.
 
 For napari-specific magicgui documentation, see the
-[napari docs](https://napari.org/guides/stable/magicgui.html)
+[napari docs](https://napari.org/guides/magicgui.html)
 
 ```{image} ../../images/param_sweep.gif
 :width: 80%
@@ -90,7 +90,7 @@ start with the actual function we'd like to write to apply a gaussian filter to 
 Our function is a very thin wrapper around
 [`skimage.filters.gaussian`](https://scikit-image.org/docs/dev/api/skimage.filters.html#skimage.filters.gaussian).
 It takes a `napari` [Image
-layer](https://napari.org/tutorials/fundamentals/image), a `sigma` to control
+layer](https://napari.org/howtos/layers/image.html), a `sigma` to control
 the blur radius, and a `mode` that determines how edges are handled.
 
 ```python
@@ -115,7 +115,7 @@ layers for our `layer` parameter, and automatically adding the result of our
 function to the viewer when called.
 
 For documentation on napari types with magicgui, see the
-[napari docs](https://napari.org/guides/stable/magicgui.html)
+[napari docs](https://napari.org/guides/magicgui.html)
 
 ### the magic part
 

--- a/examples/napari_image_arithmetic.py
+++ b/examples/napari_image_arithmetic.py
@@ -30,7 +30,7 @@ viewer.add_image(numpy.random.rand(20, 20), name="Layer 2")
 
 
 # for details on why the `-> ImageData` return annotation works:
-# https://napari.org/guides/stable/magicgui.html#return-annotations
+# https://napari.org/guides/magicgui.html#return-annotations
 @magicgui(call_button="execute", layout="horizontal")
 def image_arithmetic(layerA: Image, operation: Operation, layerB: Image) -> ImageData:
     """Add, subtracts, multiplies, or divides to image layers with equal shape."""

--- a/examples/napari_param_sweep.py
+++ b/examples/napari_param_sweep.py
@@ -21,7 +21,7 @@ viewer.add_image(skimage.data.grass().astype("float"), name="grass")
 
 # turn the gaussian blur function into a magicgui
 # for details on why the `-> ImageData` return annotation works:
-# https://napari.org/guides/stable/magicgui.html#return-annotations
+# https://napari.org/guides/magicgui.html#return-annotations
 @magicgui(
     # tells magicgui to call the function whenever a parameter changes
     auto_call=True,


### PR DESCRIPTION
Fix links to points in proper places in documentation. 

Please check if `https://napari.org/tutorials/...` links are correctly fixed.