### PR TITLE
build: pin pyside6 extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,10 @@ pyside2 =
     pyside2>=5.15 ; python_version>='3.9'
 pyqt5 =
     pyqt5>=5.12.0
+pyqt6 =
+    pyqt6
+pyside6 =
+    pyside6<6.4.0
 tqdm =
     tqdm>=4.30.0
 jupyter =

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,12 @@ passenv = CI GITHUB_ACTIONS DISPLAY XAUTHORITY
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    pyqt6: PyQt6
-    pyside6: PySide6
 extras =
     testing
     pyqt5: PyQt5
+    pyqt6: PyQt6
     pyside2: PySide2
+    pyside6: PySide6
 commands =
     python -m pytest -v --color=yes --cov-report=xml --cov=magicgui --basetemp={envtmpdir} {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ platform =
 passenv = CI GITHUB_ACTIONS DISPLAY XAUTHORITY
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
 extras =
     testing
     pyqt5: PyQt5


### PR DESCRIPTION
This pins the pyside6 extra to <6.4.0 until the nonsense with python enums is resolved.