### PR TITLE
Fix ipynb PushButton

### DIFF
--- a/magicgui/backends/_ipynb/widgets.py
+++ b/magicgui/backends/_ipynb/widgets.py
@@ -322,7 +322,14 @@ class PushButton(_IPyButtonWidget):
     _ipywidget: ipywdg.Button
 
     def _mgui_bind_change_callback(self, callback):
-        self._ipywidget.on_click(lambda e: callback())
+        self._ipywidget.on_click(lambda e: callback(False))
+
+    # ipywdg.Button does not have any value. Return False for compatibility with Qt.
+    def _mgui_get_value(self) -> float:
+        return False
+
+    def _mgui_set_value(self, value: Any) -> None:
+        pass
 
 
 class CheckBox(_IPyButtonWidget):


### PR DESCRIPTION
Fixes #463 .

The reason was that `ValueWidget._on_value_changed` does not emit signal with the default argument `value=None`.