### PR TITLE
use math.ceil to ensure get_text_width returns int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,49 @@
 # Changelog
 
-## [0.5.1](https://github.com/napari/magicgui/tree/0.5.1) (2022-06-14)
+## [v0.6.0](https://github.com/napari/magicgui/tree/v0.6.0) (2022-10-21)
 
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.5.0...0.5.1)
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.5.1...v0.6.0)
+
+**Implemented enhancements:**
+
+- Support `Literal` type [\#458](https://github.com/napari/magicgui/pull/458) ([hanjinliu](https://github.com/hanjinliu))
+- feat: add range slider \(take 2\) [\#455](https://github.com/napari/magicgui/pull/455) ([tlambert03](https://github.com/tlambert03))
+- feat: Pass parent to backend widget [\#440](https://github.com/napari/magicgui/pull/440) ([tlambert03](https://github.com/tlambert03))
+- Add ipywidgets backend [\#87](https://github.com/napari/magicgui/pull/87) ([tlambert03](https://github.com/tlambert03))
+
+**Fixed bugs:**
+
+- fix: fix deprecation warning from matplotib about accessing colormaps from mpl.cm [\#451](https://github.com/napari/magicgui/pull/451) ([tlambert03](https://github.com/tlambert03))
+- Fix FunctionGui behavior as a class method [\#443](https://github.com/napari/magicgui/pull/443) ([hanjinliu](https://github.com/hanjinliu))
+- Expose QScrollArea as native widget [\#429](https://github.com/napari/magicgui/pull/429) ([dstansby](https://github.com/dstansby))
+- Turn off adaptive step if "step" option is given [\#425](https://github.com/napari/magicgui/pull/425) ([hanjinliu](https://github.com/hanjinliu))
+
+**Tests & CI:**
+
+- tests: add test for magic-class [\#447](https://github.com/napari/magicgui/pull/447) ([tlambert03](https://github.com/tlambert03))
+- test: change pytest testing plugin [\#438](https://github.com/napari/magicgui/pull/438) ([tlambert03](https://github.com/tlambert03))
+
+**Documentation:**
+
+- Fix links in documentation [\#433](https://github.com/napari/magicgui/pull/433) ([Czaki](https://github.com/Czaki))
+- fix docs build [\#428](https://github.com/napari/magicgui/pull/428) ([tlambert03](https://github.com/tlambert03))
+- Bump jupyter-book to 0.12.x [\#427](https://github.com/napari/magicgui/pull/427) ([dstansby](https://github.com/dstansby))
+
+**Merged pull requests:**
+
+- build: pin pyside6 extra [\#460](https://github.com/napari/magicgui/pull/460) ([tlambert03](https://github.com/tlambert03))
+
+## [v0.5.1](https://github.com/napari/magicgui/tree/v0.5.1) (2022-06-14)
+
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.5.0...v0.5.1)
 
 **Fixed bugs:**
 
 - Emit signal only if value of caterogical widget changed [\#422](https://github.com/napari/magicgui/pull/422) ([Czaki](https://github.com/Czaki))
+
+**Merged pull requests:**
+
+- add changelog for v0.5.1 [\#423](https://github.com/napari/magicgui/pull/423) ([tlambert03](https://github.com/tlambert03))
 
 ## [v0.5.0](https://github.com/napari/magicgui/tree/v0.5.0) (2022-06-13)
 
@@ -294,7 +331,7 @@
 
 ## [v0.2.9](https://github.com/napari/magicgui/tree/v0.2.9) (2021-04-05)
 
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.8...v0.2.9)
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.8rc0...v0.2.9)
 
 **Implemented enhancements:**
 
@@ -320,13 +357,13 @@
 
 - \[pre-commit.ci\] pre-commit autoupdate [\#212](https://github.com/napari/magicgui/pull/212) ([pre-commit-ci[bot]](https://github.com/apps/pre-commit-ci))
 
-## [v0.2.8](https://github.com/napari/magicgui/tree/v0.2.8) (2021-03-24)
-
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.8rc0...v0.2.8)
-
 ## [v0.2.8rc0](https://github.com/napari/magicgui/tree/v0.2.8rc0) (2021-03-24)
 
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.7...v0.2.8rc0)
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.8...v0.2.8rc0)
+
+## [v0.2.8](https://github.com/napari/magicgui/tree/v0.2.8) (2021-03-24)
+
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.7...v0.2.8)
 
 **Implemented enhancements:**
 
@@ -357,7 +394,7 @@
 
 ## [v0.2.7](https://github.com/napari/magicgui/tree/v0.2.7) (2021-02-28)
 
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.6rc0...v0.2.7)
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.6...v0.2.7)
 
 **Implemented enhancements:**
 
@@ -391,13 +428,13 @@
 - update changelog [\#137](https://github.com/napari/magicgui/pull/137) ([tlambert03](https://github.com/tlambert03))
 - \[pre-commit.ci\] pre-commit autoupdate [\#136](https://github.com/napari/magicgui/pull/136) ([pre-commit-ci[bot]](https://github.com/apps/pre-commit-ci))
 
-## [v0.2.6rc0](https://github.com/napari/magicgui/tree/v0.2.6rc0) (2021-01-25)
-
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.6...v0.2.6rc0)
-
 ## [v0.2.6](https://github.com/napari/magicgui/tree/v0.2.6) (2021-01-25)
 
-[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.5...v0.2.6)
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.6rc0...v0.2.6)
+
+## [v0.2.6rc0](https://github.com/napari/magicgui/tree/v0.2.6rc0) (2021-01-25)
+
+[Full Changelog](https://github.com/napari/magicgui/compare/v0.2.5...v0.2.6rc0)
 
 **Merged pull requests:**
 

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -1181,7 +1181,7 @@ def get_text_width(text: str) -> int:
     if _might_be_rich_text(text):
         doc = QTextDocument()
         doc.setHtml(text)
-        return doc.size().width()
+        return math.ceil(doc.size().width())
     else:
         fm = QFontMetrics(QFont("", 0))
         return fm.boundingRect(text).width() + 5

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -124,7 +124,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def _mgui_set_height(self, value: int) -> None:
         """Set the current height of the widget."""
-        self._qwidget.resize(self._qwidget.width(), value)
+        self._qwidget.resize(self._qwidget.width(), int(value))
 
     def _mgui_get_min_height(self) -> int:
         """Get the minimum allowable height of the widget."""

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -98,7 +98,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def _mgui_set_width(self, value: int) -> None:
         """Set the current width of the widget."""
-        self._qwidget.resize(value, self._qwidget.height())
+        self._qwidget.resize(int(value), self._qwidget.height())
 
     def _mgui_get_min_width(self) -> int:
         """Get the minimum allowable width of the widget."""

--- a/magicgui/backends/_qtpy/widgets.py
+++ b/magicgui/backends/_qtpy/widgets.py
@@ -106,7 +106,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def _mgui_set_min_width(self, value: int) -> None:
         """Set the minimum allowable width of the widget."""
-        self._qwidget.setMinimumWidth(value)
+        self._qwidget.setMinimumWidth(int(value))
         self._qwidget.resize(self._qwidget.sizeHint())
 
     def _mgui_get_max_width(self) -> int:
@@ -115,7 +115,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def _mgui_set_max_width(self, value: int) -> None:
         """Set the maximum allowable width of the widget."""
-        self._qwidget.setMaximumWidth(value)
+        self._qwidget.setMaximumWidth(int(value))
         self._qwidget.resize(self._qwidget.sizeHint())
 
     def _mgui_get_height(self) -> int:
@@ -132,7 +132,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def _mgui_set_min_height(self, value: int) -> None:
         """Set the minimum allowable height of the widget."""
-        self._qwidget.setMinimumHeight(value)
+        self._qwidget.setMinimumHeight(int(value))
         self._qwidget.resize(self._qwidget.sizeHint())
 
     def _mgui_get_max_height(self) -> int:
@@ -141,7 +141,7 @@ class QBaseWidget(_protocols.WidgetProtocol):
 
     def _mgui_set_max_height(self, value: int) -> None:
         """Set the maximum allowable height of the widget."""
-        self._qwidget.setMaximumHeight(value)
+        self._qwidget.setMaximumHeight(int(value))
         self._qwidget.resize(self._qwidget.sizeHint())
 
     def _mgui_get_tooltip(self) -> str:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -203,8 +203,12 @@ def test_basic_widget_attributes():
     widget.label = "A different label"
     assert widget.label == "A different label"
     assert widget.width < 100
-    widget.width = 150
+    widget.width = 150.01
     assert widget.width == 150
+    widget.min_width = 100.01
+    assert widget.min_width == 100
+    widget.max_width = 200.01
+    assert widget.max_width == 200
 
     assert widget.param_kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
     widget.param_kind = inspect.Parameter.KEYWORD_ONLY

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -202,13 +202,6 @@ def test_basic_widget_attributes():
     assert widget.label == "my name"
     widget.label = "A different label"
     assert widget.label == "A different label"
-    assert widget.width < 100
-    widget.width = 150.01
-    assert widget.width == 150
-    widget.min_width = 100.01
-    assert widget.min_width == 100
-    widget.max_width = 200.01
-    assert widget.max_width == 200
 
     assert widget.param_kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
     widget.param_kind = inspect.Parameter.KEYWORD_ONLY
@@ -228,6 +221,27 @@ def test_basic_widget_attributes():
         "visible": False,
     }
     widget.close()
+
+
+def test_width_height():
+    widget = widgets.create_widget(value=1, name="my_name")
+    widget.show()
+    assert widget.visible
+    assert widget.width < 100
+
+    widget.width = 150.01
+    assert widget.width == 150
+    widget.min_width = 100.01
+    assert widget.min_width == 100
+    widget.max_width = 200.01
+    assert widget.max_width == 200
+
+    widget.height = 150.01
+    assert widget.height == 150
+    widget.min_height = 100.01
+    assert widget.min_height == 100
+    widget.max_height = 200.01
+    assert widget.max_height == 200
 
 
 def test_tooltip():


### PR DESCRIPTION
Fixes https://github.com/napari/magicgui/issues/461

I'm not sure this is strictly the best way of doing it, but this function is the source of the issue, because it can return a float as the width of the formatted text.
By using `math.ceil` the width value becomes an int and ensures the width will be sufficient (rounding up).

Alternately, one could use `int()` or use `int()` in the downstream functions that use `width`? 