### PR TITLE
fix: Fix persist on magicgui method decorator

### DIFF
--- a/magicgui/widgets/_bases/container_widget.py
+++ b/magicgui/widgets/_bases/container_widget.py
@@ -74,6 +74,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
         self._list: list[Widget] = []
         self._labels = labels
         self._layout = layout
+        self._scrollable = scrollable
         kwargs.setdefault("backend_kwargs", {})
         kwargs["backend_kwargs"].update({"layout": layout, "scrollable": scrollable})
         super().__init__(**kwargs)
@@ -333,9 +334,9 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[Widget]):
             raise
 
         for key, val in data.items():
-            val = pickle.loads(val)
-            if val != self.NO_VALUE:
-                with contextlib.suppress(ValueError, AttributeError):
+            with contextlib.suppress(ValueError, AttributeError):
+                val = pickle.loads(val)
+                if val != self.NO_VALUE:
                     getattr(self, key).value = val
 
 

--- a/magicgui/widgets/_function_gui.py
+++ b/magicgui/widgets/_function_gui.py
@@ -153,6 +153,7 @@ class FunctionGui(Container, Generic[_R]):
 
         sig = magic_signature(function, gui_options=param_options)
         self.return_annotation = sig.return_annotation
+        self._tooltips = tooltips
         if tooltips:
             _inject_tooltips_from_docstrings(function.__doc__, sig)
 
@@ -164,7 +165,7 @@ class FunctionGui(Container, Generic[_R]):
         # access attributes (like `__name__` that only function objects have).
         # Mypy doesn't seem catch this at this point:
         # https://github.com/python/mypy/issues/9934
-        name = getattr(function, "__name__", None)
+        name = name or getattr(function, "__name__", None)
         if not name:
             if hasattr(function, "func"):  # partials:
                 f = getattr(function, "func", None)
@@ -372,6 +373,11 @@ class FunctionGui(Container, Generic[_R]):
             auto_call=self._auto_call,
             result_widget=bool(self._result_widget),
             app=None,
+            persist=self.persist,
+            visible=self.visible,
+            tooltips=self._tooltips,
+            scrollable=self._scrollable,
+            name=self.name,
         )
 
     def __get__(self, obj, objtype=None) -> FunctionGui:


### PR DESCRIPTION
fixes #392

This was mainly a bug in the `FunctionGui.copy()` method, which left out `persist` when creating the duplicate