### PR TITLE
tests: skip mypy tests on all but linux

### DIFF
--- a/tests/typesafety/__init__.py
+++ b/tests/typesafety/__init__.py
@@ -3,9 +3,5 @@ import sys
 
 import pytest
 
-if (
-    os.getenv("CI")
-    and sys.version_info[:2] == (3, 10)
-    and not sys.platform.startswith("linux")
-):
+if os.getenv("CI") and not sys.platform.startswith("linux"):
     pytest.skip("Typing tests not working here at the moment.", allow_module_level=True)


### PR DESCRIPTION
the pytest mypy plugin tests are flaky ... due to upstream issues.  skipping on all but linux