### PR TITLE
refactor: remove WidgetOptions type

### DIFF
--- a/magicgui/signature.py
+++ b/magicgui/signature.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 from typing_extensions import Annotated, _AnnotatedAlias
 
 from magicgui.application import AppRef
-from magicgui.types import Undefined, WidgetOptions
+from magicgui.types import Undefined
 
 if TYPE_CHECKING:
     from magicgui.widgets import Container
@@ -62,16 +62,17 @@ def make_annotated(annotation=Any, options: dict = None) -> _AnnotatedAlias:
     return Annotated[annotation, _options]
 
 
-def split_annotated_type(annotation: _AnnotatedAlias) -> tuple[Any, WidgetOptions]:
+def split_annotated_type(annotation: _AnnotatedAlias) -> tuple[Any, dict]:
     """Split an Annotated type into its base type and options dict."""
     if not isinstance(annotation, _AnnotatedAlias):
         raise TypeError("Type hint must be an 'Annotated' type.")
-    if not isinstance(annotation.__metadata__[0], dict):
+
+    meta = annotation.__metadata__[0]
+    if not isinstance(meta, dict):
         raise TypeError(
             "Invalid Annotated format for magicgui. First arg must be a dict"
         )
 
-    meta = cast(WidgetOptions, annotation.__metadata__[0])
     return annotation.__args__[0], meta
 
 
@@ -114,7 +115,7 @@ class MagicParameter(inspect.Parameter):
         self.raise_on_unknown = raise_on_unknown
 
     @property
-    def options(self) -> WidgetOptions:
+    def options(self) -> dict:
         """Return just this options part of the annotation."""
         return split_annotated_type(self.annotation)[1]
 

--- a/magicgui/type_map.py
+++ b/magicgui/type_map.py
@@ -33,7 +33,6 @@ from magicgui.types import (
     ReturnCallback,
     Undefined,
     WidgetClass,
-    WidgetOptions,
     WidgetRef,
     WidgetTuple,
     _Undefined,
@@ -96,7 +95,7 @@ def match_type(type_: Any, default: Any = None) -> WidgetTuple | None:
             return _SIMPLE_TYPES[key], {}
 
     if type_ in (types.FunctionType,):
-        return widgets.FunctionGui, {"function": default}  # type: ignore
+        return widgets.FunctionGui, {"function": default}
 
     origin = get_origin(type_) or type_
     if origin is Literal:
@@ -196,7 +195,7 @@ def _type_optional(
 def pick_widget_type(
     value: Any = Undefined,
     annotation: Any = Undefined,
-    options: WidgetOptions | None = None,
+    options: dict | None = None,
     is_result: bool = False,
     raise_on_unknown: bool = True,
 ) -> WidgetTuple:
@@ -213,11 +212,11 @@ def pick_widget_type(
         and not choices
         and "widget_type" not in options
     ):
-        return widgets.EmptyWidget, {"visible": False, **options}  # type: ignore
+        return widgets.EmptyWidget, {"visible": False, **options}
 
     _type, optional = _type_optional(value, annotation)
     options.setdefault("nullable", optional)
-    choices = choices or (isinstance(_type, EnumMeta) and _type)  # type: ignore
+    choices = choices or (isinstance(_type, EnumMeta) and _type)
 
     if "widget_type" in options:
         widget_type = options.pop("widget_type")
@@ -236,13 +235,13 @@ def pick_widget_type(
     for registered_type in _TYPE_DEFS:
         if _type == registered_type or _is_subclass(_type, registered_type):
             _cls, opts = _TYPE_DEFS[registered_type]
-            return _cls, {**options, **opts}  # type: ignore
+            return _cls, {**options, **opts}
 
     if is_result:
         _widget_type = match_return_type(_type)
         if _widget_type:
             _cls, opts = _widget_type
-            return _cls, {**options, **opts}  # type: ignore
+            return _cls, {**options, **opts}
         # Chosen for backwards/test compatibility
         return widgets.LineEdit, {"gui_only": True}
 
@@ -254,7 +253,7 @@ def pick_widget_type(
     _widget_type = match_type(_type, value)
     if _widget_type:
         _cls, opts = _widget_type
-        return _cls, {**options, **opts}  # type: ignore
+        return _cls, {**options, **opts}
 
     if raise_on_unknown:
         raise ValueError(
@@ -267,10 +266,10 @@ def pick_widget_type(
 def get_widget_class(
     value: Any = Undefined,
     annotation: Any = Undefined,
-    options: WidgetOptions | None = None,
+    options: dict | None = None,
     is_result: bool = False,
     raise_on_unknown: bool = True,
-) -> tuple[WidgetClass, WidgetOptions]:
+) -> tuple[WidgetClass, dict]:
     """Return a WidgetClass appropriate for the given parameters.
 
     Parameters
@@ -280,7 +279,7 @@ def get_widget_class(
         is not explicitly provided by default None
     annotation : Optional[Type], optional
         A type annotation, by default None
-    options : WidgetOptions, optional
+    options : dict, optional
         Options to pass when constructing the widget, by default {}
     is_result : bool, optional
         Identifies whether the returned widget should be tailored to
@@ -290,14 +289,12 @@ def get_widget_class(
 
     Returns
     -------
-    Tuple[WidgetClass, WidgetOptions]
-        The WidgetClass, and WidgetOptions that can be used for params. WidgetOptions
+    Tuple[WidgetClass, dict]
+        The WidgetClass, and dict that can be used for params. dict
         may be different than the options passed in.
     """
-    _options = cast(WidgetOptions, options)
-
     widget_type, _options = pick_widget_type(
-        value, annotation, _options, is_result, raise_on_unknown
+        value, annotation, options, is_result, raise_on_unknown
     )
 
     if isinstance(widget_type, str):
@@ -380,7 +377,7 @@ def register_type(
         whenever the decorated function is called... where ``widget`` is the Widget
         instance, and ``value`` is the return value of the decorated function.
     **options
-        key value pairs where the keys are valid `WidgetOptions`
+        key value pairs where the keys are valid `dict`
 
     Raises
     ------
@@ -408,7 +405,7 @@ def register_type(
             _validate_return_callback(return_callback)
             _RETURN_CALLBACKS[_type_].append(return_callback)
 
-        _options = cast(WidgetOptions, options)
+        _options = cast(dict, options)
 
         if "choices" in _options:
             _TYPE_DEFS[_type_] = (widgets.ComboBox, _options)
@@ -464,7 +461,7 @@ def type_registered(
         whenever the decorated function is called... where ``widget`` is the Widget
         instance, and ``value`` is the return value of the decorated function.
     **options
-        key value pairs where the keys are valid `WidgetOptions`
+        key value pairs where the keys are valid `dict`
     """
     _type_ = resolve_single_type(type_)
 

--- a/magicgui/types.py
+++ b/magicgui/types.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 
 from enum import Enum, EnumMeta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Tuple, Type, Union
 
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
-    from magicgui._type_wrapper import TypeWrapper
     from magicgui.widgets import FunctionGui
     from magicgui.widgets._bases import CategoricalWidget, Widget
     from magicgui.widgets._protocols import WidgetProtocol
@@ -18,15 +17,8 @@ if TYPE_CHECKING:
 WidgetClass = Union[Type["Widget"], Type["WidgetProtocol"]]
 #: A generic reference to a :attr:`WidgetClass` as a string, or the class itself.
 WidgetRef = Union[str, WidgetClass]
-#: A :attr:`WidgetClass` (or a string representation of one) and a dict of appropriate
-#: :class:`WidgetOptions`.
-WidgetTuple = Tuple[WidgetRef, "WidgetOptions"]
-#: A function that takes a ``(value, annotation)`` argument and returns an optional
-#: :attr:`WidgetTuple`
-TypeMatcher = Callable[["TypeWrapper"], Optional[WidgetTuple]]
-#: A function that takes a ``(value, annotation)`` argument and returns an optional
-#: :attr:`WidgetTuple`
-ReturnMatcher = Callable[["TypeWrapper"], Optional[WidgetTuple]]
+#: A :attr:`WidgetClass` (or a string representation of one) and a dict of kwargs
+WidgetTuple = Tuple[WidgetRef, dict]
 #: An iterable that can be used as a valid argument for widget ``choices``
 ChoicesIterable = Union[Iterable[Tuple[str, Any]], Iterable[Any]]
 #: An callback that can be used as a valid argument for widget ``choices``.  It takes
@@ -62,32 +54,6 @@ class ChoicesDict(TypedDict):
 
     choices: ChoicesIterable
     key: Callable[[Any], str]
-
-
-class WidgetOptions(TypedDict, total=False):
-    """Recognized options when instantiating a Widget.
-
-    .. note::
-
-       this should be improved to be widget-type specific.
-    """
-
-    widget_type: WidgetRef
-    choices: ChoicesType
-    gui_only: bool
-    visible: bool
-    enabled: bool
-    text: str
-    min: float
-    max: float
-    step: float
-    layout: str  # for things like containers
-    orientation: str  # for things like sliders
-    mode: str | FileDialogMode
-    tooltip: str
-    bind: Any
-    nullable: bool
-    allow_multiple: bool
 
 
 class _Undefined:

--- a/magicgui/widgets/_bases/create_widget.py
+++ b/magicgui/widgets/_bases/create_widget.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from magicgui.application import use_app
 from magicgui.types import Undefined
 from magicgui.widgets import _bases, _protocols
 
 from .widget import Widget
-
-if TYPE_CHECKING:
-    from magicgui.types import WidgetOptions
 
 
 def create_widget(
@@ -22,7 +19,7 @@ def create_widget(
     gui_only=False,
     app=None,
     widget_type: str | type[_protocols.WidgetProtocol] | None = None,
-    options: WidgetOptions = dict(),
+    options: dict = dict(),
     is_result: bool = False,
     raise_on_unknown: bool = True,
 ):
@@ -59,7 +56,7 @@ def create_widget(
         magicgui widget type (e.g. "Label", "PushButton", etc...).
         If provided, this widget type will be used instead of the type
         autodetermined from ``value`` and/or ``annotation`` above.
-    options : WidgetOptions, optional
+    options : dict, optional
         Dict of options to pass to the Widget constructor, by default dict()
     is_result : boolean, optional
         Whether the widget belongs to an input or an output. By defult, an input

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -29,7 +29,7 @@ from typing_extensions import get_args, get_origin
 
 from magicgui._type_resolution import resolve_single_type
 from magicgui.application import use_app
-from magicgui.types import FileDialogMode, PathLike, WidgetOptions
+from magicgui.types import FileDialogMode, PathLike
 from magicgui.widgets import _protocols
 from magicgui.widgets._bases.container_widget import DialogWidget
 from magicgui.widgets._bases.mixins import _OrientationMixin, _ReadOnlyMixin
@@ -667,7 +667,7 @@ class ListEdit(Container):
 
     Parameters
     ----------
-    options: WidgetOptions, optional
+    options: dict, optional
         Widget options of child widgets.
     """
 
@@ -676,7 +676,7 @@ class ListEdit(Container):
         value: Iterable[_V] | _Undefined = Undefined,
         layout: str = "horizontal",
         nullable: bool = False,
-        options: WidgetOptions = None,
+        options: dict | None = None,
         **kwargs,
     ):
         self._args_type: type | None = None
@@ -687,11 +687,10 @@ class ListEdit(Container):
         if not isinstance(value, _Undefined):
             # check type consistency
             types = {type(a) for a in value}
-            if len(types) <= 1:
-                if self._args_type is None:
-                    self._args_type = types.pop()
-            else:
+            if len(types) > 1:
                 raise TypeError("values have inconsistent types.")
+            if self._args_type is None:
+                self._args_type = types.pop()
             _value: Iterable[_V] = value
         else:
             _value = []
@@ -896,7 +895,7 @@ class TupleEdit(Container):
 
     Parameters
     ----------
-    options: WidgetOptions, optional
+    options: dict, optional
         Widget options of child widgets.
     """
 
@@ -905,7 +904,7 @@ class TupleEdit(Container):
         value: Iterable[_V] | _Undefined = Undefined,
         layout: str = "horizontal",
         nullable: bool = False,
-        options: WidgetOptions = None,
+        options: dict | None = None,
         **kwargs,
     ):
         self._nullable = nullable


### PR DESCRIPTION
`WidgetOptions` was an internal TypedDict that contained most of the names used as kwargs for any widget.

However, it never worked very well, and resulted in a lot of `type: ignore` comments.

With #475  ... it's even more annoying, so this just removes it