### PR TITLE
Add Table and Quantity to API docs

### DIFF
--- a/docs/api/widgets.md
+++ b/docs/api/widgets.md
@@ -32,6 +32,7 @@ Value Widgets
    DateTimeEdit
    DateEdit
    TimeEdit
+   Table
    EmptyWidget
 
 

--- a/docs/api/widgets.md
+++ b/docs/api/widgets.md
@@ -33,6 +33,7 @@ Value Widgets
    DateEdit
    TimeEdit
    Table
+   QuantityEdit
    EmptyWidget
 
 

--- a/docs/usage/widget_overview.md
+++ b/docs/usage/widget_overview.md
@@ -131,6 +131,8 @@ following `ValueWidgets` track some `value`:
    DateTimeEdit
    DateEdit
    TimeEdit
+   Table
+   QuantityEdit
 ```
 
 ```{list-table}

--- a/magicgui/widgets/_concrete.py
+++ b/magicgui/widgets/_concrete.py
@@ -1045,4 +1045,4 @@ class _LabeledWidget(Container):
 
 @backend_widget
 class QuantityEdit(ValueWidget):
-    """A combined LineEdit and ComboBox to edit a pint.Quantity."""
+    """A combined `LineEdit` and `ComboBox` to edit a `pint.Quantity`."""

--- a/magicgui/widgets/_table.py
+++ b/magicgui/widgets/_table.py
@@ -128,7 +128,7 @@ class TableItemsView(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):
 
 
 class Table(ValueWidget, _ReadOnlyMixin, MutableMapping[TblKey, list]):
-    """A table widget representing columnar or 2D data with headers.
+    """A widget to represent columnar or 2D data with headers.
 
     Tables behave like plain `dicts`, where the keys are column headers and the
     (list-like) values are column data.


### PR DESCRIPTION
Should fix https://github.com/napari/magicgui/issues/217. I updated the first line in the docstring to have a similar style to the other ones listed in the API docs.